### PR TITLE
Prefix zmk-specific variables "Toolchain."

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ Changes in 0.3 (unreleased):
 
  * The Module.toolchain module no longer removes all object files.
 
+ * The Module.toolchain module now prefixes all non-standard variables with
+   Toolchain, to avoid confusion and clashes with user code.
 
 Changes in 0.2:
 

--- a/zmk/Module.toolchain.mk
+++ b/zmk/Module.toolchain.mk
@@ -38,24 +38,30 @@ endif
 # Deduce the kind of the selected compiler. Some build rules or compiler
 # options depend on the compiler used. As an alternative we could look at
 # preprocessor macros but this way seems sufficient for now.
-_cc := $(shell sh -c "command -v $(CC)")
-ifeq ($(_cc),/usr/bin/cc)
-_cc := $(realpath $(_cc))
+Toolchain._cc := $(shell sh -c "command -v $(CC)")
+ifeq ($(Toolchain._cc),/usr/bin/cc)
+Toolchain._cc := $(realpath $(Toolchain._cc))
 endif
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: _cc=$(_cc)))
-is_gcc=$(if $(findstring gcc,$(_cc)),yes)
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: is_gcc=$(is_gcc)))
-is_clang=$(if $(findstring clang,$(_cc)),yes)
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: is_clang=$(is_clang)))
-is_watcom=$(if $(findstring watcom,$(_cc)),yes)
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: is_watcom=$(is_watcom)))
-is_watcom_exe=$(if $(or $(findstring dos,$(_cc)),$(findstring win,$(_cc))),yes)
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: is_watcom_exe=$(is_watcom_exe)))
-is_tcc=$(if $(findstring tcc,$(_cc)),yes)
-$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: is_tcc=$(is_tcc)))
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain._cc=$(Toolchain._cc)))
+# Is CC the gcc compiler?
+Toolchain.is_gcc=$(if $(findstring gcc,$(Toolchain._cc)),yes)
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain.is_gcc=$(Toolchain.is_gcc)))
+# Is CC the clang compiler?
+Toolchain.is_clang=$(if $(findstring clang,$(Toolchain._cc)),yes)
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain.is_clang=$(Toolchain.is_clang)))
+# Is CC the open-watcom compiler?
+Toolchain.is_watcom=$(if $(findstring watcom,$(Toolchain._cc)),yes)
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain.is_watcom=$(Toolchain.is_watcom)))
+# Is CC the open-watcom compiler targeting a DOS/Windows target.
+Toolchain.is_watcom_exe=$(if $(or $(findstring dos,$(Toolchain._cc)),$(findstring win,$(Toolchain._cc))),yes)
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain.is_watcom_exe=$(Toolchain.is_watcom_exe)))
+# Is CC the tcc compiler?
+Toolchain.is_tcc=$(if $(findstring tcc,$(_cc)),yes)
+$(if $(findstring toolchain,$(DEBUG)),$(info DEBUG: Toolchain.is_tcc=$(Toolchain.is_tcc)))
 
+# The exe variable expands to .exe when the compiled binary should have such suffix.
 exe ?=
-ifeq ($(is_watcom_exe),yes)
+ifeq ($(Toolchain.is_watcom_exe),yes)
 exe = .exe
 endif
 

--- a/zmk/Template.library.so.mk
+++ b/zmk/Template.library.so.mk
@@ -24,7 +24,7 @@ $1.objects ?= $$(patsubst %.c,$1-%.o,$$($1.sources))
 $1.soname ?= $$(error define $1.soname - the name of the .so file, including version)
 $1.version-script ?= $$(warning define $1.version-script - the name of a ELF symbol map)
 # Watcom doesn't build dynamic libraries.
-ifeq (,$(is_watcom))
+ifeq (,$(Toolchain.is_watcom))
 all:: $$($1.soname)
 clean::
 	rm -f $1 $$($1.soname)
@@ -43,11 +43,11 @@ endif
 # and use the version script to define precise version mapping.
 ifneq (,$$($1.version-script))
 # Tcc does not support version scripts.
-ifeq (,$$(is_tcc))
+ifeq (,$$(Toolchain.is_tcc))
 $$($1.soname): $$($1.version-script)
 $$($1.soname): LDFLAGS += -fvisibility=hidden
 $$($1.soname): LDFLAGS += -Wl,--version-script=$$($1.version-script)
-endif # !is_tcc
+endif # !Toolchain.is_tcc
 endif # version-script
 $$($1.soname): $$($1.objects)
 	$$(strip $$(LINK.o) -o $$@ $$(filter %.o,$$^) $$(LDLIBS))
@@ -59,5 +59,5 @@ $$(DESTDIR)$$(libdir)/$$($1.soname): $$($1.soname) | $$(DESTDIR)$$(libdir)
 	install $$^ $$@
 $$(DESTDIR)$$(libdir)/$1: | $$(DESTDIR)$$(libdir)/$$($1.soname)
 	ln -s $$(notdir $$|) $$@
-endif # !is_watcom
+endif # !Toolchain.is_watcom
 endef

--- a/zmk/Template.program.mk
+++ b/zmk/Template.program.mk
@@ -58,7 +58,7 @@ all:: $1$$(exe)
 clean::
 	rm -f $1$$(exe) $1-*.o
 
-ifneq (,$$(or $$(is_gcc),$$(is_clang)))
+ifneq (,$$(or $$(Toolchain.is_gcc),$$(Toolchain.is_clang)))
 $1$$(exe): LDFLAGS += -fPIE
 endif
 $1$$(exe): $$($1.objects)

--- a/zmk/Template.program.test.mk
+++ b/zmk/Template.program.test.mk
@@ -28,7 +28,7 @@ $1.objects ?= $$(patsubst %.c,$1-%.o,$$($1.sources))
 $1.install_dir ?= $$(bindir)
 $$(eval $$(call spawn,Template.program,$1))
 
-ifneq (,$$(or $$(is_gcc),$$(is_clang)))
+ifneq (,$$(or $$(Toolchain.is_gcc),$$(Toolchain.is_clang)))
 $1$$(exe): CFLAGS += -g
 endif
 


### PR DESCRIPTION
Ahead of eventual 1.0 release, I'd like to have all zmk-specific
variables prefixed with the module they come from.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>