### PR TITLE
Detect CI with partial history

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,9 @@ Changes in 0.3 (unreleased):
  * The Template.tarball module, when used on Darwin, no longer now forgets to
    add the versioned top-level directory, matching the experience on Linux.
 
+ * The Module.git-version module now detects some CI systems and alerts the
+   user of a possiblity of a shallow git clone.
+
 Changes in 0.2:
 
  * The Template.data module now handles nested directories better.

--- a/zmk/Module.git-version.mk
+++ b/zmk/Module.git-version.mk
@@ -29,6 +29,10 @@ else
 ifneq (,$(and $(shell command -v git 2>/dev/null),$(wildcard $(srcdir)/.git)))
 # If we have the git program and the .git directory then we can also ask git.
 VERSION_git = $(shell GIT_DIR=$(srcdir)/.git git describe --abbrev=10 --tags 2>/dev/null | sed -e 's/^v//')
+# Check if we are under CI (Travis/GitHub Actions) then error if partial checkouts are used.
+ifneq ($(origin CI),undefined)
+$(if $(VERSION_git),,$(error zmk cannot compute project version from git, did the CI system use shallow clone?))
+endif
 $(if $(findstring version,$(DEBUG)),$(info DEBUG: VERSION_git=$(VERSION_git)))
 VERSION = $(or $(VERSION_git),$(VERSION_static))
 $(srcdir)/.version-from-git: $(srcdir)/.git


### PR DESCRIPTION
CI systems are incentivised to use the fewest amount of time, disk space
and network bandwidth and will use shallow git checkouts whenever
possible.

When VERSION_git is empty despite all other things looking correct AND
when the CI variable is not undefined, produce an explicit error with a
helpful message.

Fixes: #25
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>