### PR TITLE
Do not sign snapshot tarballs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@ Changes in 0.3 (unreleased):
  * The Module.toolchain module now prefixes all non-standard variables with
    Toolchain, to avoid confusion and clashes with user code.
 
+ * The Template.tarball.src module no longer signs the release archive
+   from a git-versioned snapshot.
+
 Changes in 0.2:
 
  * The Template.data module now handles nested directories better.

--- a/zmk/Template.tarball.src.mk
+++ b/zmk/Template.tarball.src.mk
@@ -28,7 +28,8 @@ $1.files += configure
 endif
 ifneq ($$(VERSION),$$(VERSION_static))
 $1.files += .version-from-git
+else
+dist:: $1.asc
 endif
 $$(eval $$(call spawn,Template.tarball,$1))
-dist:: $1.asc
 endef


### PR DESCRIPTION
Snapshot tarballs are most likely used during CI and CI should not have
release signing keys anyway.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>