### PR TITLE
Fix Tarball.mk tests on non-GNU systems

### DIFF
--- a/tests/Tarball.Src/Test.mk
+++ b/tests/Tarball.Src/Test.mk
@@ -1,14 +1,16 @@
 #!/usr/bin/make -f
 include zmk/internalTest.mk
 
-t:: dist dist-CI
+t:: dist-gnu dist-non-gnu dist-darwin dist-CI
 
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=tarball
 
 # Unset CI if we happen to see one from the likes of GitHub Actions or Travis
-dist.log: ZMK.makeOverrides += CI=
-dist: dist.log
+%.log: ZMK.makeOverrides += CI=
+
+dist-gnu.log: ZMK.makeOverrides += Tarball.isGNU=yes
+dist-gnu: dist-gnu.log
 	# Archiving source release tarball archives the files given by the user
 	GREP -qF 'tar -zcf test_1.tar.gz -C . ' <$<
 	GREP -qF 'foo.txt' <$<
@@ -16,8 +18,32 @@ dist: dist.log
 	GREP -qF 'z.mk' <$<
 	GREP -qF 'zmk/Configure.mk' <$<
 	GREP -qF 'zmk/pvs-filter.awk' <$<
+	# GNU-specific transformation syntax is supported.
+	GREP -qF -- "--xform='s@^@test_1/@g'" <$<
+	GREP -qF -- "--xform='s@.version-from-git@.version@'" <$<
 	# Releases are also signed
 	GREP -qFx 'gpg --detach-sign --armor test_1.tar.gz' <$<
+
+dist-non-gnu.log: ZMK.makeOverrides += Tarball.isGNU= OS.Kernel=test
+dist-non-gnu: dist-non-gnu.log
+	# Archiving source release tarball archives the files given by the user
+	GREP -qF 'tar -zcf test_1.tar.gz -C . ' <$<
+	GREP -qF 'foo.txt' <$<
+	# It also archives zmk (only parts are tested)
+	GREP -qF 'z.mk' <$<
+	GREP -qF 'zmk/Configure.mk' <$<
+	GREP -qF 'zmk/pvs-filter.awk' <$<
+	# BSD-specific transformation syntax is supported.
+	GREP -qF -- "-s '@.@test_1/~@'" <$<
+	GREP -qF -- "-s '@.version-from-git@.version@'" <$<
+	# Releases are also signed
+	GREP -qFx 'gpg --detach-sign --armor test_1.tar.gz' <$<
+
+dist-darwin.log: ZMK.makeOverrides += OS.Kernel=Darwin
+dist-darwin.log: ZMK.makeOverrides += Tarball.isGNU=
+dist-darwin: dist-darwin.log
+	# Darwin meta-data is excluded.
+	GREP -qF 'tar --no-mac-metadata -zcf test_1.tar.gz -C . ' <$<
 
 dist-CI.log: ZMK.makeOverrides += CI=fake
 dist-CI: dist-CI.log

--- a/zmk/Tarball.mk
+++ b/zmk/Tarball.mk
@@ -19,6 +19,8 @@ $(eval $(call ZMK.Import,OS))
 _bsd_tar_options ?=
 _tar_compress_flag ?=
 
+Tarball.isGNU ?= $(if $(shell tar --version 2>&1 | grep GNU),yes)
+
 # If using a Mac, filter out extended meta-data files.
 ifeq ($(OS.Kernel),Darwin)
 _bsd_tar_options := --no-mac-metadata
@@ -35,7 +37,7 @@ $1.Files ?= $$(error define $1.Files - the list of files to include in the tarba
 
 dist:: $1
 $1: $$(sort $$(addprefix $$(srcdir)/,$$($1.Files)))
-ifneq ($(shell tar --version 2>&1 | grep GNU),)
+ifeq ($(Tarball.isGNU),yes)
 	tar -$$(or $$(_tar_compress_flag),a)cf $$@ -C $$(srcdir) --xform='s@^@$$($1.Name)/@g' --xform='s@.version-from-git@.version@' $$(patsubst $$(srcdir)/%,%,$$^)
 else
 	tar $$(strip $$(_bsd_tar_options) -$$(or $$(_tar_compress_flag),a)cf) $$@ -C $$(srcdir) -s '@.@$$($1.Name)/~@' -s '@.version-from-git@.version@' $$(patsubst $$(srcdir)/%,%,$$^)


### PR DESCRIPTION
The test had two flaws: it was not mocking the properties of the system
actually used by Tarball.mk (GNU vs BSD tar and OS.Kernel) and this went
unnoticed on Darwin due to the GREP vs grep bug that was recently
discovered.

Add appropriate mocking and test four variants: GNU, non-GNU, Darwin and
under CI.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>