### PR TITLE
Remove needless $(shell sh -c ...) pattern

### DIFF
--- a/zmk/ManPage.mk
+++ b/zmk/ManPage.mk
@@ -17,7 +17,7 @@
 $(eval $(call ZMK.Import,Directories))
 
 # ManPage.isAvailable expand to "yes" when the man command is available.
-ManPage.isAvailable ?= $(if $(shell sh -c "command -v man" 2>/dev/null),yes)
+ManPage.isAvailable ?= $(if $(shell command -v man 2>/dev/null),yes)
 # ManPage.isGNU expands to "yes" when man is the GNU man implementation, with various additional options over BSD.
 ManPage.isGNU ?= $(if $(and $(ManPage.isAvailable),$(shell man --help 2>&1 | grep -F -- --warning)),yes)
 

--- a/zmk/Tarball.mk
+++ b/zmk/Tarball.mk
@@ -16,7 +16,7 @@
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,OS))
 
-Tarball.tar ?= $(shell sh -c "command -v tar" 2>/dev/null)
+Tarball.tar ?= $(shell command -v tar 2>/dev/null)
 Tarball.isGNU ?= $(if $(shell $(Tarball.tar) --version 2>&1 | grep GNU),yes)
 
 # When using MacOS, ask tar not to store mac-specific meta-data through .DS_Store files.

--- a/zmk/Toolchain.mk
+++ b/zmk/Toolchain.mk
@@ -58,8 +58,8 @@ Toolchain.DependencyTracking ?= $(Configure.DependencyTracking)
 # Deduce the kind of the selected compiler. Some build rules or compiler
 # options depend on the compiler used. As an alternative we could look at
 # preprocessor macros but this way seems sufficient for now.
-Toolchain.cc ?= $(shell sh -c "command -v $(CC)")
-Toolchain.cxx ?= $(shell sh -c "command -v $(CXX)")
+Toolchain.cc ?= $(shell command -v $(CC) 2>/dev/null)
+Toolchain.cxx ?= $(shell command -v $(CXX) 2>/dev/null)
 
 # When CC or CXX point to platform default compiler alias, resolve
 # them to the real value, which is better to identify the toolchain.

--- a/zmk/toolchain.GCC.mk
+++ b/zmk/toolchain.GCC.mk
@@ -17,7 +17,7 @@ endif # !cross-compiling
 endif # !configured
 
 # Indirection for testability.
-Toolchain.gcc ?= $(shell sh -c "command -v gcc 2>/dev/null")
+Toolchain.gcc ?= $(shell command -v gcc 2>/dev/null)
 Toolchain.cc.dumpmachine  ?= $(shell $(CC)  -dumpmachine)
 Toolchain.gcc.dumpmachine ?= $(if $(Toolchain.gcc),$(shell gcc    -dumpmachine))
 
@@ -55,7 +55,7 @@ endif # !cross-compiling
 endif # !configured
 
 # Indirection for testability.
-Toolchain.g++ ?= $(shell sh -c "command -v g++ 2>/dev/null")
+Toolchain.g++ ?= $(shell command -v g++ 2>/dev/null)
 Toolchain.cxx.dumpmachine ?= $(shell $(CXX) -dumpmachine)
 Toolchain.g++.dumpmachine ?= $(if $(Toolchain.g++),$(shell g++    -dumpmachine))
 


### PR DESCRIPTION
The make $(shell) function already invokes the shell.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>