### PR TITLE
Introduce Project.{Name,Version}

### DIFF
--- a/z.mk
+++ b/z.mk
@@ -14,8 +14,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
-NAME ?= $(error define NAME - the name of the project)
-VERSION ?= $(error define VERSION - the static version of the project)
+ifneq ($(value NAME),)
+Project.Name ?= $(NAME)
+else
+Project.Name ?=
+endif
+NAME ?= $(or $(Project.Name),$(error define NAME - the name of the project))
+
+ifneq ($(value VERSION),)
+Project.Version ?= $(VERSION)
+else
+Project.Version ?=
+endif
+VERSION ?= $(or $(Project.Version),$(error define VERSION - the static version of the project))
 
 # Speed up make by removing suffix rules.
 .SUFFIXES:


### PR DESCRIPTION
Those variables have the same purpose as NAME and VERSION, and in fact
are more generic version of the two. While both NAME and VERSION default
to $(error), the new variables show either NAME and VERSION if defined
or expand to an empty value.

This allows safer usage of Project.Name instead of NAME and
Project.Version instead of VERSION, without having to carefully handle
the error defaults.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>