### PR TITLE
Define $(docdir) based on $(Project.Name) instead of $(NAME)

### DIFF
--- a/man/zmk.Directories.5.in
+++ b/man/zmk.Directories.5.in
@@ -115,9 +115,9 @@ The default value is
 Directory with documentation specific to the project.
 .Pp
 The default value is
-.Em $(prefix)/doc/$(NAME) .
-Since the value depends on NAME, it is only defined
-when NAME is also defined.
+.Em $(prefix)/doc/$(Project.Name) .
+Since the value depends on Project.Name, it is only defined
+when Project.Name is non-empty.
 .Ss infodir
 Directory with documentation in the Info format.
 .Pp

--- a/zmk/Directories.mk
+++ b/zmk/Directories.mk
@@ -57,9 +57,9 @@ Directories.POSIX = \
 	$(man2dir) $(man3dir) $(man4dir) $(man5dir) $(man6dir) $(man7dir) \
 	$(man8dir) $(man9dir)
 
-# If NAME is defined, also define docdir.
-ifneq ($(value NAME),$$(error define NAME - the name of the project))
-docdir ?= $(datarootdir)/doc/$(NAME)
+# If Project.Name is defined, also define docdir.
+ifneq ($(Project.Name),)
+docdir ?= $(datarootdir)/doc/$(Project.Name)
 Directories.POSIX += $(docdir)
 endif
 


### PR DESCRIPTION
This is easier to handle correctly as NAME evolves into Project.Name.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>