### PR TITLE
Add support for silent rules across zmk

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,14 +36,16 @@ $(foreach f,$(ZMK.DistFiles),$(eval $(call ZMK.Expand,InstallUninstall,$f)))
 # Install all of the manual pages, generating them from .in files first.
 all:: $(foreach f,$(ZMK.manPages),man/$f)
 clean::
-	rm -f $(addprefix man/,$(ZMK.manPages))
+	$(call Silent.Say,RM,$(addprefix man/,$(ZMK.manPages)))
+	$(Silent.Command)rm -f $(addprefix man/,$(ZMK.manPages))
 ifneq ($(ZMK.SrcDir),.)
-	test -d man && rmdir man || :
+	$(Silent.Command)test -d man && rmdir man || :
 endif
 $(CURDIR)/man: # For out-of-tree builds.
-	install -d $@
+	$(Silent.Command)install -d $@
 man/%: man/%.in | $(CURDIR)/man
-	sed -e 's/@VERSION@/$(VERSION)/g' $< >$@
+	$(call Silent.Say,SED,$@)
+	$(Silent.Command)sed -e 's/@VERSION@/$(VERSION)/g' $< >$@
 $(foreach f,$(ZMK.manPages),$(eval $(call ZMK.Expand,ManPage,man/$f)))
 
 # Build the release tarball.
@@ -84,16 +86,18 @@ check-unit: $(addprefix check-,$(tests))
 
 check-%: ZMK.testDir=$(patsubst examples/libhello/%,examples/libhello-%,$(patsubst examples/hello/%,examples/hello-%,$(subst -,/,$*)))
 $(addprefix check-,$(tests)): check-%:
+	$(call Silent.Say,MAKE-TEST,$(TESTDIR))
 ifeq ($(ZMK.IsOutOfTreeBuild),yes)
-	mkdir -p $(ZMK.testDir)
-	$(strip $(MAKE) \
+	$(Silent.Command)mkdir -p $(ZMK.testDir)
+	$(Silent.Command)$(strip $(MAKE) \
 		--warn-undefined-variables \
 		ZMK.test.SrcDir=$(ZMK.SrcDir)/$(ZMK.testDir) \
 		-I $(abspath $(ZMK.Path)) \
 		-C $(ZMK.testDir) \
 		-f $(ZMK.SrcDir)/$(ZMK.testDir)/Test.mk)
 else
-	$(strip $(MAKE)	--warn-undefined-variables \
+	$(Silent.Command)$(strip $(MAKE) \
+		--warn-undefined-variables \
 		-I $(abspath $(ZMK.Path)) \
 		-C $(ZMK.testDir) \
 		-f Test.mk)

--- a/man/zmk.Silent.5.in
+++ b/man/zmk.Silent.5.in
@@ -1,0 +1,66 @@
+.Dd October 21, 2020
+.Os zmk @VERSION@
+.Dt zmk.Silent 5 PRM
+.Sh NAME
+.Nm Silent
+.Nd module for supporting silent rules
+.Sh SYNOPSIS
+.Bd -literal
+include z.mk
+$(eval $(call ZMK.Import,Silent))
+.Ed
+.Sh DESCRIPTION
+The
+.Nm Silent
+module, once
+.Em imported ,
+provides functions and variables for supporting
+.Em silent rules .
+Silent rules are a configuration option, trading precision of the exact
+commands used by the build system, for better visibility of warnings and other
+output. When enabled, actual commands executed by Make are hidden and a
+symbolic representation replaced with a symbolic representation devoid of
+details.
+.Pp
+Silent rules are usually a configuration option of a specific build workspace.
+To enable, execute the
+.Em configure
+script with the option
+.Em --enable-silent-rules .
+.Sh TARGETS
+This module does not provide any targets.
+.Sh VARIABLES
+This module provides the following variables.
+.Ss Silent.Active
+The global silent mode toggle. Any non-empty value enables silent rules.
+This is automatically configured by the
+.Nm Configure
+module.
+.Ss Silent.Command
+Expands to
+.Em @
+when silent rules are active. Can be placed in front of commands of a make rule
+to cause make not to echo the command itself. It should be paired with
+.Nm Silent.Say
+for the complete experience.
+.Ss Silent.Say
+Function expanding to a shell command printing the 1st and 2nd argument.
+The first argument should be the symbolic name of the tool, such as CC
+or LD. The second argument should be the resulting file, i.e. $@.
+.Sh EXAMPLES
+A hypothetical rule for compiling .foo files to .fooobj files, supporting silent
+rules, might look like this.
+.Bd -literal -offset indent
+include z.mk
+$(eval $(call ZMK.Import,Silent))
+
+%.fooobj: %.foo
+    $(eval $(call Silent.Say,FOOCC,$@))
+    $(Silent.Command)foocc -c $^ -o $@
+.Ed
+.Sh HISTORY
+The
+.Nm
+module first appeared in zmk 0.4
+.Sh AUTHORS
+.An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/tests/Directories/Test.mk
+++ b/tests/Directories/Test.mk
@@ -2,13 +2,14 @@
 include zmk/internalTest.mk
 
 t:: debug-defaults debug-name-defined debug-destdir debug-prefix \
-	debug-sysconfdir debug-libexecdir
+	debug-sysconfdir debug-libexecdir debug-silent-rules
 
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=directories,directory
 
 debug-defaults: debug-defaults.log
 	GREP -qFx 'DEBUG: prefix=/usr/local' <$<
+	GREP -qFx 'install -d /usr' <$<
 	GREP -qFx 'install -d /usr/local' <$<
 	GREP -qFx 'install -d /usr/local/bin' <$<
 	GREP -qFx 'install -d /usr/local/sbin' <$<
@@ -32,6 +33,10 @@ debug-defaults: debug-defaults.log
 	GREP -qFx 'install -d /usr/local/share/man/man7' <$<
 	GREP -qFx 'install -d /usr/local/share/man/man8' <$<
 	GREP -qFx 'install -d /usr/local/share/man/man9' <$<
+
+debug-silent-rules.log: ZMK.makeOverrides += Silent.Active=yes
+debug-silent-rules: debug-silent-rules.log
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr"' <$<
 
 debug-name-defined.log: ZMK.makeOverrides += NAME=test
 debug-name-defined: debug-name-defined.log

--- a/tests/Directory/Test.mk
+++ b/tests/Directory/Test.mk
@@ -1,10 +1,12 @@
 #!/usr/bin/make -f
 include zmk/internalTest.mk
 
-t:: debug debug-destdir
+t:: debug debug-silent-rules debug-destdir
 
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=directory
+# Some logs have slent rules enabled
+%-silent-rules.log: ZMK.makeOverrides += Silent.Active=yes
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
 
@@ -25,6 +27,39 @@ debug: debug.log
 	GREP -qFx 'install -d /other' <$<
 	GREP -qFx 'install -d /other/custom' <$<
 	GREP -qFx 'install -d /other/custom/path' <$<
+
+debug-silent-rules: debug-silent-rules.log
+	# Directory in the build tree
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "subdir"' <$<
+	GREP -qFx '#install -d subdir' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "subdir/subsubdir"' <$<
+	GREP -qFx '#install -d subdir/subsubdir' <$<
+	# Extension of standard directory.
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr"' <$<
+	GREP -qFx '#install -d /usr' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local"' <$<
+	GREP -qFx '#install -d /usr/local' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local/lib"' <$<
+	GREP -qFx '#install -d /usr/local/lib' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local/lib/extra"' <$<
+	GREP -qFx '#install -d /usr/local/lib/extra' <$<
+	# Custom shallow directory.
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/foo"' <$<
+	GREP -qFx '#install -d /foo' <$<
+	# Custom deep directory with implicit parent rules.
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/custom"' <$<
+	GREP -qFx '#install -d /custom' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/custom/long"' <$<
+	GREP -qFx '#install -d /custom/long' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/custom/long/path"' <$<
+	GREP -qFx '#install -d /custom/long/path' <$<
+	# Custom deep directory with explicit parent rules.
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/other"' <$<
+	GREP -qFx '#install -d /other' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/other/custom"' <$<
+	GREP -qFx '#install -d /other/custom' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/other/custom/path"' <$<
+	GREP -qFx '#install -d /other/custom/path' <$<
 
 debug-destdir: debug-destdir.log
 	# Directory in the build tree - note lack of destdir

--- a/tests/Header/Test.mk
+++ b/tests/Header/Test.mk
@@ -3,10 +3,13 @@
 include zmk/internalTest.mk
 
 t:: all install uninstall clean \
+    all-silent-rules install-silent-rules uninstall-silent-rules clean-silent-rules \
     all-destdir install-destdir uninstall-destdir clean-destdir
 
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=header
+# Some logs have slent rules enabled
+%-silent-rules.log: ZMK.makeOverrides += Silent.Active=yes
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
 # Test depends on source files
@@ -15,6 +18,8 @@ t:: all install uninstall clean \
 all: all.log
 	GREP -qF 'Nothing to be done for' <$<
 install: install.log
+	GREP -qFx 'install -d /usr' <$<
+	GREP -qFx 'install -d /usr/local' <$<
 	GREP -qFx 'install -d /usr/local/include' <$<
 	GREP -qFx 'install -m 0644 $(ZMK.test.OutOfTreeSourcePath)foo.h /usr/local/include/foo.h' <$<
 	GREP -qFx 'install -m 0644 $(ZMK.test.OutOfTreeSourcePath)include/bar.h /usr/local/include/bar.h' <$<
@@ -22,6 +27,27 @@ uninstall: uninstall.log
 	GREP -qFx 'rm -f /usr/local/include/foo.h' <$<
 	GREP -qFx 'rm -f /usr/local/include/bar.h' <$<
 clean: clean.log
+	GREP -qF 'Nothing to be done for' <$<
+
+all-silent-rules: all-silent-rules.log
+	GREP -qF 'Nothing to be done for' <$<
+install-silent-rules: install-silent-rules.log
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr"' <$<
+	GREP -qFx '#install -d /usr' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local"' <$<
+	GREP -qFx '#install -d /usr/local' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local/include"' <$<
+	GREP -qFx '#install -d /usr/local/include' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "INSTALL" "/usr/local/include/foo.h"' <$<
+	GREP -qFx '#install -m 0644 $(ZMK.test.OutOfTreeSourcePath)foo.h /usr/local/include/foo.h' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "INSTALL" "/usr/local/include/bar.h"' <$<
+	GREP -qFx '#install -m 0644 $(ZMK.test.OutOfTreeSourcePath)include/bar.h /usr/local/include/bar.h' <$<
+uninstall-silent-rules: uninstall-silent-rules.log
+	GREP -qFx 'printf "  %-16s %s\n" "RM" "/usr/local/include/foo.h"' <$<
+	GREP -qFx '#rm -f /usr/local/include/foo.h' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "RM" "/usr/local/include/bar.h"' <$<
+	GREP -qFx '#rm -f /usr/local/include/bar.h' <$<
+clean-silent-rules: clean-silent-rules.log
 	GREP -qF 'Nothing to be done for' <$<
 
 all-destdir: all-destdir.log

--- a/tests/Library.A/Test.mk
+++ b/tests/Library.A/Test.mk
@@ -3,39 +3,93 @@
 include zmk/internalTest.mk
 
 t:: all install uninstall clean \
+    all-silent-rules install-silent-rules uninstall-silent-rules clean-silent-rules \
     all-destdir install-destdir uninstall-destdir clean-destdir
 
 $(eval $(ZMK.isolateHostToolchain))
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=library.a
+# Some logs have slent rules enabled
+%-silent-rules.log: ZMK.makeOverrides += Silent.Active=yes
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
 # Test depends on source files
 %.log: foo.c
 
 all: all.log
+	# Default target compiles source to object files belonging to the library.
 	GREP -qFx 'cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	# Default target combines object files into an archive
 	GREP -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<
 install: install.log
+	# Installing creates the prerequisite directories
+	GREP -qFx 'install -d /usr' <$<
+	GREP -qFx 'install -d /usr/local' <$<
+	# Installing creates the library directory
 	GREP -qFx 'install -d /usr/local/lib' <$<
+	# Installing copies the library
 	GREP -qFx 'install -m 0644 libfoo.a /usr/local/lib/libfoo.a' <$<
 uninstall: uninstall.log
+	# Uninstalling removes the library
 	GREP -qFx 'rm -f /usr/local/lib/libfoo.a' <$<
 clean: clean.log
+	# Cleaning removes the library
 	GREP -qFx 'rm -f libfoo.a' <$<
+	# Cleaning removes the object files belonging to the library
 	GREP -qFx 'rm -f libfoo.a-foo.o' <$<
+	# Cleaning removes the dependency files
 	GREP -qFx 'rm -f libfoo.a-foo.d' <$<
 
+all-silent-rules: all-silent-rules.log
+	# Default target compiles source to object files belonging to the library.
+	GREP -qFx 'printf "  %-16s %s\n" "CC" "libfoo.a-foo.o"' <$<
+	GREP -qFx '#cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	# Default target combines object files into an archive
+	GREP -qFx 'printf "  %-16s %s\n" "AR" "libfoo.a"' <$<
+	GREP -qFx '#ar -cr libfoo.a libfoo.a-foo.o' <$<
+install-silent-rules: install-silent-rules.log
+	# Installing creates the prerequisite directories
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr"' <$<
+	GREP -qFx '#install -d /usr' <$<
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local"' <$<
+	GREP -qFx '#install -d /usr/local' <$<
+	# Installing creates the library directory
+	GREP -qFx 'printf "  %-16s %s\n" "MKDIR" "/usr/local/lib"' <$<
+	GREP -qFx '#install -d /usr/local/lib' <$<
+	# Installing copies the library
+	GREP -qFx 'printf "  %-16s %s\n" "INSTALL" "/usr/local/lib/libfoo.a"' <$<
+	GREP -qFx '#install -m 0644 libfoo.a /usr/local/lib/libfoo.a' <$<
+uninstall-silent-rules: uninstall-silent-rules.log
+	GREP -qFx '#rm -f /usr/local/lib/libfoo.a' <$<
+clean-silent-rules: clean-silent-rules.log
+	# Cleaning removes the library
+	GREP -qFx '#rm -f libfoo.a' <$<
+	# Cleaning removes the object files belonging to the library
+	GREP -qFx '#rm -f libfoo.a-foo.o' <$<
+	# Cleaning removes the dependency files
+	GREP -qFx '#rm -f libfoo.a-foo.d' <$<
+
 all-destdir: all-destdir.log
+	# Default target compiles source to object files belonging to the library.
 	GREP -qFx 'cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	# Default target combines object files into an archive
 	GREP -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<
 install-destdir: install-destdir.log
+	# Installing creates the prerequisite directories
 	GREP -qFx 'mkdir -p /destdir' <$<
+	GREP -qFx 'install -d /destdir/usr' <$<
+	GREP -qFx 'install -d /destdir/usr/local' <$<
+	# Installing creates the library directory
 	GREP -qFx 'install -d /destdir/usr/local/lib' <$<
+	# Installing copies the library
 	GREP -qFx 'install -m 0644 libfoo.a /destdir/usr/local/lib/libfoo.a' <$<
 uninstall-destdir: uninstall-destdir.log
+	# Uninstalling removes the library
 	GREP -qFx 'rm -f /destdir/usr/local/lib/libfoo.a' <$<
 clean-destdir: clean-destdir.log
+	# Cleaning removes the library
 	GREP -qFx 'rm -f libfoo.a' <$<
+	# Cleaning removes the object files belonging to the library
 	GREP -qFx 'rm -f libfoo.a-foo.o' <$<
+	# Cleaning removes the dependency files
 	GREP -qFx 'rm -f libfoo.a-foo.d' <$<

--- a/z.mk
+++ b/z.mk
@@ -61,6 +61,7 @@ ZMK.modules = \
 	Program.Test \
 	PVS \
 	Script \
+	Silent \
 	Symlink \
 	Tarball \
 	Tarball.Src \
@@ -79,6 +80,7 @@ ZMK.manPages = \
 	zmk.OS.5 \
 	zmk.Program.5 \
 	zmk.Script.5 \
+	zmk.Silent.5 \
 	zmk.Toolchain.5
 
 # Files belonging to ZMK that need to be distributed in third-party release tarballs.

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 # Is zmk debugging enabled for this module?
 Configure.debug ?= $(findstring configure,$(DEBUG))
 
@@ -36,6 +38,11 @@ Configure.Options ?=
 # location. One place where this happens is zmk test suite.
 ifneq (,$(Project.Name))
 -include GNUmakefile.$(Project.Name).configure.mk
+endif
+
+# Enable silent rules if configured.
+ifneq (,$(Configure.Configured))
+override Silent.Active = $(Configure.SilentRules)
 endif
 
 $(if $(Configure.debug),$(foreach v,$(filter Configure.%,$(.VARIABLES)),$(info DEBUG: $v=$($v))))
@@ -299,17 +306,20 @@ ifeq ($(Configure.MaintainerMode),yes)
 $(CURDIR)/configure configure: export ZMK_CONFIGURE_SCRIPT = $(Configure.script)
 $(CURDIR)/configure configure: $(ZMK.Path)/z.mk $(wildcard $(ZMK.Path)/zmk/*.mk)
 	@echo "$${ZMK_CONFIGURE_SCRIPT}" >$@
-	chmod +x $@
+	$(call Silent.Say,GENERATE,$@)
+	$(Silent.Command)chmod +x $@
 
 # In maintainer mode, re-configure in response to updates to the configuration script.
 ifeq ($(Configure.Configured),yes)
 GNUmakefile.$(Project.Name).configure.mk: configure
-	@echo "re-configuring, $< script is newer than $@"
-	$(strip sh $< $(sort $(Configure.Options) ZMK.SrcDir=$(ZMK.SrcDir)))
+	$(call Silent.Say,CONFIGURE,$(sort $(Configure.Options) ZMK.SrcDir=$(ZMK.SrcDir)))
+	$(if Configure.SilentRules,,@echo "re-configuring, $< script is newer than $@")
+	$(Silent.Command)$(strip sh $< $(sort $(Configure.Options) ZMK.SrcDir=$(ZMK.SrcDir)))
 # Enable silent rules if configured to do so.
 override Silent.Active = $(Configure.SilentRules)
 endif # !configured
 endif # !maintainer mode
 distclean::
-	rm -f GNUmakefile.$(Project.Name).configure.mk
+	$(call Silent.Say,RM,GNUmakefile.$(Project.Name).configure.mk)
+	$(Silent.Command)rm -f GNUmakefile.$(Project.Name).configure.mk
 endif # !project name set

--- a/zmk/Coverity.mk
+++ b/zmk/Coverity.mk
@@ -14,14 +14,20 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 Coverity.Sources ?= $(error define Coverity.Sources - the list of source files to analyze with Coverity)
 
 clean::
-	rm -rf cov-int
-	rm -f $(NAME)-$(VERSION)-coverity.tar.gz
+	$(call Silent.Say,RM,cov-int)
+	$(Silent.Command)rm -rf cov-int
+	$(call Silent.Say,RM,$(NAME)-$(VERSION)-coverity.tar.gz)
+	$(Silent.Command)rm -f $(NAME)-$(VERSION)-coverity.tar.gz
 
 cov-int: $(Coverity.Sources) $(MAKEFILE_LIST)
-	cov-build --dir $@ $(MAKE)
+	$(call Silent.Say,COV-BUILD,$@)
+	$(Silent.Command)cov-build --dir $@ $(MAKE)
 
 $(NAME)-$(VERSION)-coverity.tar.gz: cov-int
-	tar zcf $@ $<
+	$(call Silent.Say,TAR,$@)
+	$(Silent.Command)tar zcf $@ $<

--- a/zmk/Directory.mk
+++ b/zmk/Directory.mk
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 Directory.debug ?= $(findstring directory,$(DEBUG))
 
 # List of directories that need to be created and have corresponding rules.
@@ -29,7 +31,8 @@ ifeq ($(origin DESTDIR),undefined)
 DESTDIR ?=
 else
 $(DESTDIR):
-	mkdir -p $@
+	$(call Silent.Say,MKDIR,$@)
+	$(Silent.Command)mkdir -p $@
 # Warn if DESTDIR is defined in a makefile. This is probably a mistake.
 ifeq ($(origin DESTDIR),file)
 $(warning DESTDIR should be set only through environment variable, not in a makefile)
@@ -58,11 +61,13 @@ Directory.known += $$($1.cleaned)
 ifeq (/,$$(patsubst /%,/,$$($1.cleaned)))
 # Absolute directories respect DESTDIR
 $$(DESTDIR)$$($1.cleaned): | $$(DESTDIR)$$($1.parentDir)
-	install -d $$@
+	$$(call Silent.Say,MKDIR,$$@)
+	$$(Silent.Command)install -d $$@
 else
 # Relative directories do not observe DESTDIR
 $$($1.cleaned): | $$($1.parentDir)
-	install -d $$@
+	$$(call Silent.Say,MKDIR,$$@)
+	$$(Silent.Command)install -d $$@
 endif # !absolute
 endif # !known
 endif # !.

--- a/zmk/GitVersion.mk
+++ b/zmk/GitVersion.mk
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 # Craft a better version if we have Git.
 
 GitVersion.debug ?= $(findstring version,$(DEBUG))
@@ -51,7 +53,8 @@ endif # !version from version file
 # for git information anymore, as it may no longer be the "same" git history.
 ifneq (,$(GitVersion.versionFromGit))
 $(ZMK.SrcDir)/.version-from-git: $(ZMK.SrcDir)/.git
-	echo $(GitVersion.versionFromGit) >$@
+	$(Silent.Say,GIT-VERSION,$@)
+	$(Silent.Command)echo $(GitVersion.versionFromGit) >$@
 endif
 
 # Set the new effective VERSION.

--- a/zmk/InstallUninstall.mk
+++ b/zmk/InstallUninstall.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 
 # A file that gets installed to a desired location. The location can be set
@@ -31,10 +32,12 @@ ifneq ($$($1.InstallDir),noinst)
 
 install:: $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName)
 uninstall::
-	rm -f $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName)
+	$$(call Silent.Say,RM,$$($1.InstallDir)/$$($1.InstallName))
+	$$(Silent.Command)rm -f $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName)
 
 $$(eval $$(call ZMK.Expand,Directory,$$($1.InstallDir)))
 $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName): $1 | $$(DESTDIR)$$($1.InstallDir)
-	$$(strip install -m $$($1.InstallMode) $$^ $$@)
+	$$(call Silent.Say,INSTALL,$$@)
+	$$(Silent.Command)$$(strip install -m $$($1.InstallMode) $$^ $$@)
 endif # noinst
 endef

--- a/zmk/Library.A.mk
+++ b/zmk/Library.A.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,Toolchain))
 
@@ -28,7 +29,8 @@ $$(eval $$(call ZMK.Expand,ObjectGroup,$1))
 
 # Create library archive.
 $1: $$($1.Objects)
-	$$(AR) $$(ARFLAGS) $$@ $$^
+	$$(call Silent.Say,AR,$$@)
+	$$(Silent.Command)$$(AR) $$(ARFLAGS) $$@ $$^
 
 # Install library archive.
 $1.InstallDir ?= $$(libdir)

--- a/zmk/Library.DyLib.mk
+++ b/zmk/Library.DyLib.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,Toolchain))
 
@@ -43,7 +44,8 @@ endif
 
 # Link library objects.
 $1: $$($1.Objects)
-	$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$(filter %.o,$$^) $$(LDLIBS))
+	$$(call Silent.Say,$$($1.SuggestedLinkerSymbol),$$@)
+	$$(Silent.Command)$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$(filter %.o,$$^) $$(LDLIBS))
 
 # Install library binary.
 $1.InstallDir ?= $$(libdir)

--- a/zmk/Library.So.mk
+++ b/zmk/Library.So.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,Toolchain))
 
@@ -55,7 +56,8 @@ endif # VersionScript
 
 # Link library objects.
 $1: $$($1.Objects)
-	$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$(filter %.o,$$^) $$(LDLIBS))
+	$$(call Silent.Say,$$($1.SuggestedLinkerSymbol),$$@)
+	$$(Silent.Command)$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$(filter %.o,$$^) $$(LDLIBS))
 
 # Install library binary.
 $1.InstallDir ?= $$(libdir)

--- a/zmk/ManPage.mk
+++ b/zmk/ManPage.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 
 # ManPage.isAvailable expand to "yes" when the man command is available.
@@ -31,7 +32,8 @@ ifeq ($(ManPage.isGNU),yes)
 %.man-check: ManPage.manOpts += --local-file
 .PHONY: %.man-check
 %.man-check: %
-	LC_ALL=C MANROFFSEQ= MANWIDTH=80 man $(ManPage.manOpts) $< 2>&1 >/dev/null | sed -e 's@tbl:<standard input>@$*@g'
+	$(call Silent.Say,MAN,$<)
+	$(Silent.Command)LC_ALL=C MANROFFSEQ= MANWIDTH=80 man $(ManPage.manOpts) $< 2>&1 >/dev/null | sed -e 's@tbl:<standard input>@$*@g'
 static-check-manpages::
 static-check:: static-check-manpages
 endif

--- a/zmk/ObjectGroup.mk
+++ b/zmk/ObjectGroup.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Toolchain))
 $(eval $(call ZMK.Import,OS))
 
@@ -24,6 +25,7 @@ $1.ObjectsC ?= $$(addsuffix .o,$$(addprefix $1-,$$(basename $$(filter %.c,$$($1.
 $1.ObjectsCxx ?= $$(addsuffix .o,$$(addprefix $1-,$$(basename $$(filter %.cpp,$$($1.Sources)))))
 $1.ObjectsObjC ?= $$(addsuffix .o,$$(addprefix $1-,$$(basename $$(filter %.m,$$($1.Sources)))))
 $1.Objects ?= $$(strip $$($1.ObjectsC) $$($1.ObjectsCxx) $$($1.ObjectsObjC))
+$1.SuggestedLinkerSymbol ?= $$(if $$($1.ObjectsObjC),OBJCLD,$$(if $$($1.ObjectsCxx),CXXLD,CCLD))
 
 # Check if we have the required compiler.
 $$(if $$(or $$($1.ObjectsC),$$($1.ObjectsObjC)),$$(if $$(Toolchain.CC.IsAvailable),,$$(error Building $1 requires a C compiler)))
@@ -31,16 +33,21 @@ $$(if $$($1.ObjectsCxx),$$(if $$(Toolchain.CXX.IsAvailable),,$$(error Building $
 
 # This is how to compile each type of source files.
 $$($1.ObjectsC): $1-%.o: %.c
-	$$(strip $$(COMPILE.c) -o $$@ $$<)
+	$$(call Silent.Say,CC,$$@)
+	$$(Silent.Command)$$(strip $$(COMPILE.c) -o $$@ $$<)
 $$($1.ObjectsCxx): $1-%.o: %.cpp
-	$$(strip $$(COMPILE.cc) -o $$@ $$<)
+	$$(call Silent.Say,CXX,$$@)
+	$$(Silent.Command)$$(strip $$(COMPILE.cc) -o $$@ $$<)
 $$($1.ObjectsObjC): $1-%.o: %.m
-	$$(strip $$(COMPILE.m) -o $$@ $$<)
+	$$(call Silent.Say,OBJC,$$@)
+	$$(Silent.Command)$$(strip $$(COMPILE.m) -o $$@ $$<)
 
 clean::
-	rm -f $$($1.Objects)
+	$$(call Silent.Say,RM,$$($1.Objects))
+	$$(Silent.Command)rm -f $$($1.Objects)
 ifneq (,$$(Toolchain.DependencyTracking))
-	rm -f $$($1.Objects:.o=.d)
+	$$(call Silent.Say,RM,$$($1.Objects:.o=.d))
+	$$(Silent.Command)rm -f $$($1.Objects:.o=.d)
 endif
 
 ifneq (,$$(Toolchain.DependencyTracking))

--- a/zmk/PVS.mk
+++ b/zmk/PVS.mk
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 PVS.Sources ?= $(error define PVS.Sources - the list of source files to analyze with PVS Studio)
 
 PLOG_CONVERTER_FLAGS ?=
@@ -25,14 +27,16 @@ endif
 
 .PHONY: static-check-pvs
 static-check-pvs: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
-	$(strip plog-converter \
+	$(call Silent.Say,PLOG-CONVERTER,$@)
+	$(Silent.Command)$(strip plog-converter \
 		--settings $(ZMK.SrcDir)/.pvs-studio.cfg \
 		$(PLOG_CONVERTER_FLAGS) \
 		--srcRoot $(ZMK.SrcDir) \
 		--renderTypes errorfile $^ | srcdir=$(ZMK.SrcDir) abssrcdir=$(abspath $(ZMK.SrcDir)) awk -f $(ZMK.Path)/zmk/pvs-filter.awk)
 
 pvs-report: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
-	$(strip plog-converter \
+	$(call Silent.Say,PLOG-CONVERTER,$@)
+	$(Silent.Command)$(strip plog-converter \
 		--settings $(ZMK.SrcDir)/.pvs-studio.cfg \
 		$(PLOG_CONVERTER_FLAGS) \
 		--srcRoot $(ZMK.SrcDir) \
@@ -43,20 +47,27 @@ pvs-report: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
 		$^)
 
 %.c.PVS-Studio.log: %.c.i ~/.config/PVS-Studio/PVS-Studio.lic | %.c
-	$(strip pvs-studio \
+	$(call Silent.Say,PVS-STUDIO,$@)
+	$(Silent.Command)$(strip pvs-studio \
 		--cfg $(ZMK.SrcDir)/.pvs-studio.cfg \
 		--i-file $< \
 		--source-file $(firstword $|) \
 		--output-file $@)
 
 %.c.i: %.c
-	$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
+	$(call Silent.Say,CPP,$@)
+	$(Silent.Command)$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
 %.cpp.i: %.cpp
-	$(strip $(CXX) $(CPPFLAGS) $< -E -o $@)
+	$(call Silent.Say,CPP,$@)
+	$(Silent.Command)$(strip $(CXX) $(CPPFLAGS) $< -E -o $@)
 %.m.i: %.m
-	$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
+	$(call Silent.Say,CPP,$@)
+	$(Silent.Command)$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
 
 clean::
-	rm -f *.i
-	rm -f *.PVS-Studio.log
-	rm -rf pvs-report
+	$(call Silent.Say,RM,*.i)
+	$(Silent.Command)rm -f *.i
+	$(call Silent.Say,RM,*.PVS-Studio.log)
+	$(Silent.Command)rm -f *.PVS-Studio.log
+	$(call Silent.Say,RM,pvs-report)
+	$(Silent.Command)rm -rf pvs-report

--- a/zmk/Program.mk
+++ b/zmk/Program.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,Toolchain))
 $(eval $(call ZMK.Import,OS))
@@ -30,7 +31,8 @@ ifneq (,$$($1.ObjectsObjC))
 $1$$(exe): LDLIBS += -lobjc
 endif # no objective C objects
 $1$$(exe): $$($1.Objects)
-	$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$^ $$(LDLIBS))
+	$$(call Silent.Say,$$($1.SuggestedLinkerSymbol),$$@)
+	$$(Silent.Command)$$(strip $$(if $$($1.ObjectsObjC),$$(LINK.m),$$(if $$($1.ObjectsCxx),$$(LINK.cc),$$(LINK.o))) -o $$@ $$^ $$(LDLIBS))
 
 # Install program binary.
 $1.InstallDir ?= $$(bindir)

--- a/zmk/Script.mk
+++ b/zmk/Script.mk
@@ -14,14 +14,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 
 ZMK.shellcheck ?= $(shell command -v shellcheck 2>/dev/null)
 static-check-shellcheck:
 ifneq (,$(ZMK.shellcheck))
-	$(ZMK.shellcheck) $^
+	$(call Silent.Say,SHELLCHECK,$^)
+	$(Silent.Command)$(ZMK.shellcheck) $^
 else
-	@echo "ZMK: install shellcheck to analyze $^" 
+	@echo "ZMK: install shellcheck to analyze $^"
 endif
 static-check:: static-check-shellcheck
 

--- a/zmk/Silent.mk
+++ b/zmk/Silent.mk
@@ -14,12 +14,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
-$(eval $(call ZMK.Import,Silent))
-
-AllClean.Variables=
-define AllClean.Template
-all:: $1
-clean::
-	$$(call Silent.Say,RM,$1)
-	$$(Silent.Command)rm -f $1
-endef
+# Is zmk debugging enabled for this module?
+Silent.Active?=
+ifeq (,$(value ZMK.testing))
+Silent.Command=$(if $(Silent.Active),@)
+else
+# ZMK is being tested, mainly, by running make -n and measuring the output.
+# Make ignores the non-echo rule when -n is in effect. As such, to improve
+# testing of silent rules, when zmk is being tested pretend all silent rules
+# are commented-out shell commands. This can be readily verified by simple grep
+# patterns.
+Silent.Command=$(if $(Silent.Active),\#)
+endif
+Silent.Say=$(if $(Silent.Active),@printf "  %-16s %s\n" "$1" "$2")

--- a/zmk/Symlink.mk
+++ b/zmk/Symlink.mk
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
 
 # Symbolic link. Gets installed to the desired location. The location can be
 # set using the .InstallDir instance variable. The special value of noinst
@@ -30,7 +31,8 @@ $1.sourceDir = $$(patsubst %/,%,$$(dir $1))
 $$(eval $$(call ZMK.Expand,Directory,$$($1.sourceDir)))
 # Create the symbolic link in the build directory.
 $1: | $$($1.sourceDir)
-	$$(strip ln -s $$($1.SymlinkTarget) $$@)
+	$$(call Silent.Say,SYMLINK,$$@)
+	$$(Silent.Command)$$(strip ln -s $$($1.SymlinkTarget) $$@)
 # React to "all" and "clean" targets.
 $$(eval $$(call ZMK.Expand,AllClean,$1))
 
@@ -42,11 +44,13 @@ $1.targetDir = $$(patsubst %/,%,$$(dir $$($1.InstallDir)/$1))
 $$(eval $$(call ZMK.Expand,Directory,$$($1.targetDir)))
 # Create the symbolic link in the install directory.
 $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName):| $$(DESTDIR)$$($1.targetDir)
-	$$(strip ln -s $$($1.SymlinkTarget) $$@)
+	$$(call Silent.Say,SYMLINK,$$@)
+	$$(Silent.Command)$$(strip ln -s $$($1.SymlinkTarget) $$@)
 # React to "install" and "uninstall" targets.
 install:: $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName)
 uninstall::
-	rm -f $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName)
+	$$(call Silent.Say,RM,$$($1.targetDir)/$$($1.InstallName))
+	$$(Silent.Command)rm -f $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName)
 else # noinst
 $1.targetDir = noinst
 endif # !noinst

--- a/zmk/Tarball.Src.mk
+++ b/zmk/Tarball.Src.mk
@@ -14,8 +14,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
 
+$(eval $(call ZMK.Import,Silent))
+
 %.asc: %
-		gpg --detach-sign --armor $<
+	$(call Silent.Say,GPG-SIGN,$@)
+	$(Silent.Command)gpg --detach-sign --armor $<
 
 # Allow preventing ZMK from ever being bundled.
 ZMK.DoNotBundle ?= $(if $(value ZMK_DO_NOT_BUNDLE),yes)

--- a/zmk/Tarball.mk
+++ b/zmk/Tarball.mk
@@ -13,6 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Zmk.  If not, see <https://www.gnu.org/licenses/>.
+
+$(eval $(call ZMK.Import,Silent))
 $(eval $(call ZMK.Import,Directories))
 $(eval $(call ZMK.Import,OS))
 
@@ -59,7 +61,8 @@ $1: Tarball.tarOptions += -s '@^.@$$($1.Name)/~@'
 endif
 
 $1: $$(sort $$($1.Files))
-	$$(strip $$(Tarball.tar) \
+	$$(call Silent.Say,TAR,$$@)
+	$$(Silent.Command)$$(strip $$(Tarball.tar) \
 		-$$(or $$(Tarball.compressFlag),a)cf $$@ \
 		$$(if $$(ZMK.IsOutOfTreeBuild),-C $$(ZMK.SrcDir)) \
 		$$(Tarball.tarOptions) \

--- a/zmk/internalTest.mk
+++ b/zmk/internalTest.mk
@@ -74,4 +74,5 @@ ZMK.makeTarget ?=
 $(CURDIR)/configure configure: $(ZMK.test.Path)/zmk/internalTest.mk
 
 c::
-	rm -f *.log
+	$(Silent.Say,RM,*.log)
+	$(Silent.Command)rm -f *.log


### PR DESCRIPTION
When configured with --enable-silent-rules, zmk will now honor this
preference and emit different output. Almost almost all the modules
which create any output were adjusted.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>