### PR TITLE
Do not sign tarballs when there's no gpg or key

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -71,7 +71,7 @@ $(ZMK.releaseArchive).Files += $(addprefix tests/ManPage/,Makefile Test.mk foo.1
 $(ZMK.releaseArchive).Files += $(addprefix tests/OS/,Makefile Test.mk)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Program/,Makefile Test.mk foo.c bar.cpp froz.m)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Symlink/,Makefile Test.mk)
-$(ZMK.releaseArchive).Files += $(addprefix tests/Tarball.Src/,Makefile Test.mk foo.txt)
+$(ZMK.releaseArchive).Files += $(addprefix tests/Tarball.Src/,Makefile Test.mk foo.txt home/alice/.gnupg/fake-gpg-data home/bob/.gitkeep home/eve/.gnupg/fake-gpg-data)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Toolchain/,Makefile Test.mk)
 $(ZMK.releaseArchive).Files += tests/bin/GREP
 $(eval $(call ZMK.Expand,Tarball.Src,$(ZMK.releaseArchive)))

--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,9 @@ Changes in the next release:
   was disabled in an earlier release as it was showing a problem with zmk
   that was not understood at the time.
 
+* The Tarball.Src module only signs the release if both GPG and GPG keys are
+  available.
+
 Changes in 0.3.8:
 
 * The release archive now contains the full collection of test files.

--- a/tests/Tarball.Src/home/alice/.gnupg/fake-gpg-data
+++ b/tests/Tarball.Src/home/alice/.gnupg/fake-gpg-data
@@ -1,0 +1,1 @@
+This file keeps the home-dir/.gnupg directory around

--- a/tests/Tarball.Src/home/eve/.gnupg/fake-gpg-data
+++ b/tests/Tarball.Src/home/eve/.gnupg/fake-gpg-data
@@ -1,0 +1,1 @@
+This file keeps the home-dir/.gnupg directory around


### PR DESCRIPTION
Singing release tarballs is not universally practiced. A system without
either gpg itself or any gpg keys cannot sign the release archive so
don't try to.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>