### PR TITLE
Fix quoting of hash/pound in makefiles

### DIFF
--- a/man/z.mk.5.in
+++ b/man/z.mk.5.in
@@ -219,6 +219,12 @@ find the source code without modification.
 .Sh INTERNAL VARIABLES
 .Ss ZMK.z.mk
 Path of the entry point of the zmk library.
+.Ss ZMK.comma
+Variable expanding to a comma.
+.Ss ZMK.newline
+Variable expanding to a newline.
+.Ss ZMK.hash
+Variable expanding to a hash-or-pound symbol.
 .Sh HISTORY
 The primary interface of zmk was first documented zmk 0.4
 .Sh AUTHORS

--- a/z.mk
+++ b/z.mk
@@ -119,13 +119,18 @@ check:: static-check
 # Default goal is to build everything, regardless of declaration order
 .DEFAULT_GOAL = all
 
-# Display diagnostic messages when DEBUG has specific items.
+# Some weird Make quirks. Depending on MAKE version, it's hard to use literal
+# hash but it's possible to expand ZMK.hash to it reliably.
+ZMK.hash=\#
+# Comma is also hard to use directly.
 ZMK.comma=,
+# Newline is just hard to define.
 define ZMK.newline
 
 
 endef
 DEBUG ?=
+# Display diagnostic messages when DEBUG has specific items.
 DEBUG := $(subst $(ZMK.comma), ,$(DEBUG))
 
 # Define the module and template system.

--- a/zmk/Silent.mk
+++ b/zmk/Silent.mk
@@ -24,6 +24,6 @@ else
 # testing of silent rules, when zmk is being tested pretend all silent rules
 # are commented-out shell commands. This can be readily verified by simple grep
 # patterns.
-Silent.Command=$(if $(Silent.Active),\#)
+Silent.Command=$(if $(Silent.Active),$(ZMK.hash))
 endif
 Silent.Say=$(if $(Silent.Active),@printf "  %-16s %s\n" "$1" "$2")


### PR DESCRIPTION
Casual inspection of log files generated during testing of silent rules
uncovered a discrepancy between how GNU Make 4.3 and 3.81 handle the
hash-or-pound symbol.

I didn't look at the source to understand what exactly changed in the
parser but I've managed to resolve this and get consistent behavior by
using an intermediate variable.

There's no impact on any unit tests.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>