### PR TITLE
Fix .exe suffix in installed programs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@ Changes in the next release:
   correctly when invoked with -B switch (aka --always-make), by force-creating
   symbolic links that already exist.
 
+* Program template no longer forgets to add the .exe suffix to installed executables.
+
 * The ObjectGroup template used by Program, Program.Test, Library.A, Library.So
   and Library.DyLib is now performing rudimentary detection of a missing compiler.
 

--- a/tests/Program/Test.mk
+++ b/tests/Program/Test.mk
@@ -105,6 +105,7 @@ install-program-transform-name: install-program-transform-name.log
 	GREP -qFx 'cc -o foo foo-foo.o' <$<
 	GREP -qFx 'install -m 0755 foo /usr/local/bin/potato' <$<
 
+t:: install-exe
 install-exe.log: ZMK.makeOverrides += exe=.exe
 install-exe: install-exe.log
 	# C/C++ programs respect the .exe suffix (during installation)

--- a/zmk/Program.mk
+++ b/zmk/Program.mk
@@ -39,7 +39,7 @@ $1.InstallDir ?= $$(bindir)
 $1.InstallMode ?= 0755
 ifneq (,$$(filter Configure,$$(ZMK.ImportedModules)))
 $1.InstallName ?= $$(if $$(Configure.ProgramTransformName),$$(shell echo '$$(Configure.ProgramPrefix)$$(notdir $1)$$(Configure.ProgramSuffix)' | sed -e '$$(Configure.ProgramTransformName)'),$$(Configure.ProgramPrefix)$$(notdir $1)$$(Configure.ProgramSuffix))
-$1$$(exe).InstallName ?= $$($1.InstallName)
+$1$$(exe).InstallName ?= $$($1.InstallName)$$(exe)
 endif
 $1$$(exe).InstallDir ?= $$($1.InstallDir)
 $1$$(exe).InstallMode ?= $$($1.InstallMode)


### PR DESCRIPTION
Ironically the test that was checking this was never invoked and the
code was obviously broken.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>