### PR TITLE
Support unclean directory names

### DIFF
--- a/zmk/Directory.mk
+++ b/zmk/Directory.mk
@@ -60,11 +60,18 @@ endif # !parent empty
 Directory.known += $$($1.cleaned)
 ifeq (/,$$(patsubst /%,/,$$($1.cleaned)))
 # Absolute directories respect DESTDIR
+$(if $(Directory.debug),$(info DEBUG: absolute directory $$($1.cleaned)$$(if $$(DESTDIR), with prefixed DESTDIR=$$(DESTDIR))))
 $$(DESTDIR)$$($1.cleaned): | $$(DESTDIR)$$($1.parentDir)
 	$$(call Silent.Say,MKDIR,$$@)
 	$$(Silent.Command)install -d $$@
+ifneq ($1,$$($1.cleaned))
+# Unclean directory path (with trailing slash) order-depends on the clean directory path
+$(if $(Directory.debug),$(info DEBUG: absolute unclean directory $1 corresponding to $$($1.cleaned)$$(if $$(DESTDIR), with prefixed DESTDIR=$$(DESTDIR))))
+$$(DESTDIR)$1: | $$(DESTDIR)$$($1.cleaned)
+endif
 else
 # Relative directories do not observe DESTDIR
+$(if $(Directory.debug),$(info DEBUG: relative directory $$($1.cleaned)))
 $$($1.cleaned): | $$($1.parentDir)
 	$$(call Silent.Say,MKDIR,$$@)
 	$$(Silent.Command)install -d $$@


### PR DESCRIPTION
When the Directory template is expanded with an unclean path, such as
/path/to/foo/, the trailing slash is automatically removed and the mkdir
rule exists only of the canonical path: /path/to/foo. This is correct
but may lead to misleading results when some other rule depends on the
unclean path's existence. For simplicity emit a support rule which
order-depends on the clean path from the unclean path.

In terms of make rules it looks somewhat like this:

/path/to/foo:
	install -d $@
/path/to/foo/: | /path/to/foo

In particular, this fixes sub-directory creation, during out-of-tree
builds of sources using src/foo.c layout.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>