### PR TITLE
Improve subdir handling in PVS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Changes in the next release:
+Changes in the upcoming release:
 
 * The Library.So template will no longer create symlink foo -> foo.so when the
   library is not versioned.
@@ -9,6 +9,8 @@ Changes in the next release:
 
 * Out-of-tree builds when the original project uses $(ZMK.OutOfTreeSourcePath),
   explicitly, for example to use the $(wildcard) function, no longer fail.
+
+* The PVS module now handles sub-directories, similar to ObjectGroup.
 
 Backwards incompatible changes in 0.4:
 

--- a/zmk/PVS.mk
+++ b/zmk/PVS.mk
@@ -16,9 +16,32 @@
 
 $(eval $(call ZMK.Import,Silent))
 
+# Sources are not re-defined with := so that they can expand lazily.
 PVS.Sources ?= $(error define PVS.Sources - the list of source files to analyze with PVS Studio)
+# NOTE: Strip out the out-of-tree-source-path so that all the $1.sources (note
+# the lower-case) variables use source-relative paths. This is important when
+# we want to derive object paths using source paths (same file with .o
+# extension replaced but rooted at the build tree, not the source tree). When
+# ZMK needs to support generated source files this should be changed.
+PVS.sources = $(patsubst $(ZMK.OutOfTreeSourcePath)%,%,$(PVS.Sources))
 
 PLOG_CONVERTER_FLAGS ?=
+
+define PVS.PreProcess
+$1.i: $$(ZMK.OutOfTreeSourcePath)$1 | $$(patsubst %/,%,$$(CURDIR)/$$(dir $1))
+	$$(call Silent.Say,CPP,$$@)
+	$$(Silent.Command)$$(strip $$(CPP) $$(CPPFLAGS) $$< -E -o $$@)
+endef
+
+define PVS.Analyze
+$1.PVS-Studio.log: $1.i ~/.config/PVS-Studio/PVS-Studio.lic | $$(ZMK.OutOfTreeSourcePath)$1
+	$$(call Silent.Say,PVS-STUDIO,$$@)
+	$$(Silent.Command)$$(strip pvs-studio \
+		--cfg $$(ZMK.OutOfTreeSourcePath).pvs-studio.cfg \
+		--i-file $$< \
+		--source-file $$(firstword $$|) \
+		--output-file $$@)
+endef
 
 # If we have pvs-studio then run it during static checks.
 ifneq (,$(shell command -v pvs-studio 2>/dev/null))
@@ -26,18 +49,21 @@ static-check:: static-check-pvs
 endif
 
 .PHONY: static-check-pvs
-static-check-pvs: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
+static-check-pvs: $(addsuffix .PVS-Studio.log,$(PVS.sources))
 	$(call Silent.Say,PLOG-CONVERTER,$@)
 	$(Silent.Command)$(strip plog-converter \
-		--settings $(ZMK.SrcDir)/.pvs-studio.cfg \
+		--settings $(ZMK.OutOfTreeSourcePath).pvs-studio.cfg \
 		$(PLOG_CONVERTER_FLAGS) \
 		--srcRoot $(ZMK.SrcDir) \
 		--renderTypes errorfile $^ | srcdir=$(ZMK.SrcDir) abssrcdir=$(abspath $(ZMK.SrcDir)) awk -f $(ZMK.Path)/zmk/pvs-filter.awk)
 
-pvs-report: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
+$(foreach src,$(PVS.sources),$(eval $(call PVS.PreProcess,$(src))))
+$(foreach src,$(PVS.sources),$(eval $(call PVS.Analyze,$(src))))
+
+pvs-report: $(addsuffix .PVS-Studio.log,$(PVS.sources))
 	$(call Silent.Say,PLOG-CONVERTER,$@)
 	$(Silent.Command)$(strip plog-converter \
-		--settings $(ZMK.SrcDir)/.pvs-studio.cfg \
+		--settings $(ZMK.OutOfTreeSourcePath)/.pvs-studio.cfg \
 		$(PLOG_CONVERTER_FLAGS) \
 		--srcRoot $(ZMK.SrcDir) \
 		--projectName $(NAME) \
@@ -46,28 +72,10 @@ pvs-report: $(addsuffix .PVS-Studio.log,$(PVS.Sources))
 		--output $@ \
 		$^)
 
-%.c.PVS-Studio.log: %.c.i ~/.config/PVS-Studio/PVS-Studio.lic | %.c
-	$(call Silent.Say,PVS-STUDIO,$@)
-	$(Silent.Command)$(strip pvs-studio \
-		--cfg $(ZMK.SrcDir)/.pvs-studio.cfg \
-		--i-file $< \
-		--source-file $(firstword $|) \
-		--output-file $@)
-
-%.c.i: %.c
-	$(call Silent.Say,CPP,$@)
-	$(Silent.Command)$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
-%.cpp.i: %.cpp
-	$(call Silent.Say,CPP,$@)
-	$(Silent.Command)$(strip $(CXX) $(CPPFLAGS) $< -E -o $@)
-%.m.i: %.m
-	$(call Silent.Say,CPP,$@)
-	$(Silent.Command)$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
-
 clean::
 	$(call Silent.Say,RM,*.i)
-	$(Silent.Command)rm -f *.i
+	$(Silent.Command)rm -f $(addsuffix .i,$(PVS.sources))
 	$(call Silent.Say,RM,*.PVS-Studio.log)
-	$(Silent.Command)rm -f *.PVS-Studio.log
+	$(Silent.Command)rm -f $(addsuffix .PVS-Studio.log,$(PVS.sources))
 	$(call Silent.Say,RM,pvs-report)
 	$(Silent.Command)rm -rf pvs-report


### PR DESCRIPTION
Similarly to what happened to ObjectGroup recently, PVS module now supports
sub-directories correctly.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>