### PR TITLE
Fix out-of-tree build with read-only source tree

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,7 +31,7 @@ Changes in 0.4:
 * Program template no longer forgets to add the .exe suffix to installed executables.
 
 * The ObjectGroup template used by Program, Program.Test, Library.A, Library.So
-  and Library.Dylib now supports sub-directories in source file names. Object files
+  and Library.DyLib now supports sub-directories in source file names. Object files
   created by the object group are now created in directories corresponding to the source
   files.
 

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ Changes in the next release:
 * The Library.So template will no longer create symlink foo -> foo.so when the
   library is not versioned.
 
+* Out-of-tree builds with dependency generation and sub-directories in source
+  file paths no longer fail by attempting to put the generated dependency
+  information alongside the source code.
+
 Backwards incompatible changes in 0.4:
 
 * The Configure module introduces a backwards incompatible change in the

--- a/examples/hello-c/Test.mk
+++ b/examples/hello-c/Test.mk
@@ -7,7 +7,7 @@ t:: all install uninstall clean
 $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
-	GREP -qFx 'cc -MMD -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF hello-hello.d) -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'cc -o hello hello-hello.o' <$<
 install: install.log
 	GREP -qFx 'install -d /usr/local/bin' <$<

--- a/examples/hello-cpp/Test.mk
+++ b/examples/hello-cpp/Test.mk
@@ -11,8 +11,8 @@ $(eval $(ZMK.isolateHostToolchain))
 %.log: ZMK.makeOverrides += CXX=c++
 
 all: all.log
-	GREP -qFx 'c++ -MMD -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
-	GREP -qFx 'c++ -MMD -o hello hello-hello.o' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF hello-hello.d) -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -o hello hello-hello.o' <$<
 install: install.log
 	GREP -qFx 'install -d /usr/local/bin' <$<
 	GREP -qFx 'install -m 0755 hello /usr/local/bin/hello' <$<

--- a/examples/hello-objc/Test.mk
+++ b/examples/hello-objc/Test.mk
@@ -7,8 +7,8 @@ t:: all install uninstall clean
 $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
-	GREP -qFx 'cc -MMD -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
-	GREP -qFx 'cc -MMD -o hello hello-hello.o -lobjc' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF hello-hello.d) -c -o hello-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -o hello hello-hello.o -lobjc' <$<
 install: install.log
 	GREP -qFx 'install -d /usr/local/bin' <$<
 	GREP -qFx 'install -m 0755 hello /usr/local/bin/hello' <$<

--- a/examples/libhello-c/Test.mk
+++ b/examples/libhello-c/Test.mk
@@ -17,7 +17,7 @@ uninstall: uninstall-other uninstall-linux uninstall-macos
 clean: clean-other clean-linux clean-macos
 
 all-other: all-other.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
 install-other: install-other.log
 	GREP -qFx 'install -d /usr/local/include' <$<
@@ -32,9 +32,9 @@ clean-other: clean-other.log
 	GREP -qFx 'rm -f ./libhello.a-hello.o' <$<
 
 all-linux: all-linux.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.so.1-hello.d) -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'cc -shared -Wl,-soname=libhello.so.1 -o libhello.so.1 libhello.so.1-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.so.1 libhello.so' <$<
 install-linux: install-linux.log
@@ -57,9 +57,9 @@ clean-linux: clean-linux.log
 	GREP -qFx 'rm -f libhello.so' <$<
 
 all-macos: all-macos.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.1.dylib-hello.d) -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.c' <$<
 	GREP -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libhello.1.dylib libhello.1.dylib-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.1.dylib libhello.dylib' <$<
 install-macos: install-macos.log

--- a/examples/libhello-cpp/Test.mk
+++ b/examples/libhello-cpp/Test.mk
@@ -21,7 +21,7 @@ uninstall: uninstall-other uninstall-linux uninstall-macos
 clean: clean-other clean-linux clean-macos
 
 all-other: all-other.log
-	GREP -qFx 'c++ -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
 install-other: install-other.log
 	GREP -qFx 'install -d /usr/local/include' <$<
@@ -36,10 +36,10 @@ clean-other: clean-other.log
 	GREP -qFx 'rm -f ./libhello.a-hello.o' <$<
 
 all-linux: all-linux.log
-	GREP -qFx 'c++ -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'c++ -fpic -MMD -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
-	GREP -qFx 'c++ -fpic -MMD -shared -Wl,-soname=libhello.so.1 -o libhello.so.1 libhello.so.1-hello.o' <$<
+	GREP -qFx 'c++ -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.so.1-hello.d) -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -fpic -shared -Wl,-soname=libhello.so.1 -o libhello.so.1 libhello.so.1-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.so.1 libhello.so' <$<
 install-linux: install-linux.log
 	GREP -qFx 'install -d /usr/local/include' <$<
@@ -61,10 +61,10 @@ clean-linux: clean-linux.log
 	GREP -qFx 'rm -f libhello.so' <$<
 
 all-macos: all-macos.log
-	GREP -qFx 'c++ -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'c++ -fpic -MMD -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
-	GREP -qFx 'c++ -fpic -MMD -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libhello.1.dylib libhello.1.dylib-hello.o' <$<
+	GREP -qFx 'c++ -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.1.dylib-hello.d) -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.cpp' <$<
+	GREP -qFx 'c++ -fpic -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libhello.1.dylib libhello.1.dylib-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.1.dylib libhello.dylib' <$<
 install-macos: install-macos.log
 	GREP -qFx 'install -d /usr/local/include' <$<

--- a/examples/libhello-objc/Test.mk
+++ b/examples/libhello-objc/Test.mk
@@ -17,7 +17,7 @@ uninstall: uninstall-other uninstall-linux uninstall-macos
 clean: clean-other clean-linux clean-macos
 
 all-other: all-other.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
 install-other: install-other.log
 	GREP -qFx 'install -d /usr/local/include' <$<
@@ -32,10 +32,10 @@ clean-other: clean-other.log
 	GREP -qFx 'rm -f ./libhello.a-hello.o' <$<
 
 all-linux: all-linux.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
-	GREP -qFx 'cc -fpic -MMD -shared -Wl,-soname=libhello.so.1 -o libhello.so.1 libhello.so.1-hello.o' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.so.1-hello.d) -c -o libhello.so.1-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -fpic -shared -Wl,-soname=libhello.so.1 -o libhello.so.1 libhello.so.1-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.so.1 libhello.so' <$<
 install-linux: install-linux.log
 	GREP -qFx 'install -d /usr/local/include' <$<
@@ -57,10 +57,10 @@ clean-linux: clean-linux.log
 	GREP -qFx 'rm -f libhello.so' <$<
 
 all-macos: all-macos.log
-	GREP -qFx 'cc -MMD -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.a-hello.d) -c -o libhello.a-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
 	GREP -qFx 'ar -cr libhello.a libhello.a-hello.o' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
-	GREP -qFx 'cc -fpic -MMD -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libhello.1.dylib libhello.1.dylib-hello.o' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libhello.1.dylib-hello.d) -c -o libhello.1.dylib-hello.o $(ZMK.test.OutOfTreeSourcePath)hello.m' <$<
+	GREP -qFx 'cc -fpic -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libhello.1.dylib libhello.1.dylib-hello.o' <$<
 	GREP -qFx 'ln -sf libhello.1.dylib libhello.dylib' <$<
 install-macos: install-macos.log
 	GREP -qFx 'install -d /usr/local/include' <$<

--- a/examples/true_false/Test.mk
+++ b/examples/true_false/Test.mk
@@ -7,7 +7,7 @@ t:: all
 $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
-	GREP -qFx 'cc -MMD -DEXIT_CODE=EXIT_SUCCESS -c -o true-true_false.o $(ZMK.test.OutOfTreeSourcePath)true_false.c' <$<
+	GREP -qFx 'cc -DEXIT_CODE=EXIT_SUCCESS -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF true-true_false.d) -c -o true-true_false.o $(ZMK.test.OutOfTreeSourcePath)true_false.c' <$<
 	GREP -qFx 'cc -o true true-true_false.o' <$<
-	GREP -qFx 'cc -MMD -DEXIT_CODE=EXIT_FAILURE -c -o false-true_false.o $(ZMK.test.OutOfTreeSourcePath)true_false.c' <$<
+	GREP -qFx 'cc -DEXIT_CODE=EXIT_FAILURE -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF false-true_false.d) -c -o false-true_false.o $(ZMK.test.OutOfTreeSourcePath)true_false.c' <$<
 	GREP -qFx 'cc -o false false-true_false.o' <$<

--- a/tests/Library.A/Test.mk
+++ b/tests/Library.A/Test.mk
@@ -18,7 +18,7 @@ $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
 	# Default target compiles source to object files belonging to the library.
-	GREP -qFx 'cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.a-foo.d) -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
 	# Default target combines object files into an archive
 	GREP -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<
 install: install.log
@@ -43,7 +43,7 @@ clean: clean.log
 all-silent-rules: all-silent-rules.log
 	# Default target compiles source to object files belonging to the library.
 	GREP -qFx 'printf "  %-16s %s\n" "CC" "libfoo.a-foo.o"' <$<
-	GREP -qFx '#cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx '#cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.a-foo.d) -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
 	# Default target combines object files into an archive
 	GREP -qFx 'printf "  %-16s %s\n" "AR" "libfoo.a"' <$<
 	GREP -qFx '#ar -cr libfoo.a libfoo.a-foo.o' <$<
@@ -71,7 +71,7 @@ clean-silent-rules: clean-silent-rules.log
 
 all-destdir: all-destdir.log
 	# Default target compiles source to object files belonging to the library.
-	GREP -qFx 'cc -MMD -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.a-foo.d) -c -o libfoo.a-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
 	# Default target combines object files into an archive
 	GREP -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<
 install-destdir: install-destdir.log

--- a/tests/Library.DyLib/Test.mk
+++ b/tests/Library.DyLib/Test.mk
@@ -15,7 +15,7 @@ $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
 	# Building a dynamic library compiles objects
-	GREP -qFx 'cc -fpic -MMD -c -o libfoo.1.dylib-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.1.dylib-foo.d) -c -o libfoo.1.dylib-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
 	# Links objects together
 	GREP -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<
 	# And provides the .so alias
@@ -43,7 +43,7 @@ clean: clean.log
 
 all-destdir: all-destdir.log
 	# Building a dynamic library compiles objects
-	GREP -qFx 'cc -fpic -MMD -c -o libfoo.1.dylib-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.1.dylib-foo.d) -c -o libfoo.1.dylib-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
 	# Links objects together
 	GREP -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<
 	# And provides the .so alias

--- a/tests/Library.So/Test.mk
+++ b/tests/Library.So/Test.mk
@@ -15,8 +15,8 @@ $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
 	# Building a shared library compiles objects
-	GREP -qFx 'cc -fpic -MMD -c -o libfoo.so.1-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libbar.so-bar.o $(ZMK.test.OutOfTreeSourcePath)bar.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.so.1-foo.d) -c -o libfoo.so.1-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libbar.so-bar.d) -c -o libbar.so-bar.o $(ZMK.test.OutOfTreeSourcePath)bar.c' <$<
 	# Links objects together
 	GREP -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<
 	GREP -qFx 'cc -shared -Wl,-soname=libbar.so -o libbar.so libbar.so-bar.o' <$<
@@ -54,10 +54,11 @@ clean: clean.log
 
 all-destdir: all-destdir.log
 	# Building a shared library compiles objects
-	GREP -qFx 'cc -fpic -MMD -c -o libfoo.so.1-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
-	GREP -qFx 'cc -fpic -MMD -c -o libbar.so-bar.o $(ZMK.test.OutOfTreeSourcePath)bar.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libfoo.so.1-foo.d) -c -o libfoo.so.1-foo.o $(ZMK.test.OutOfTreeSourcePath)foo.c' <$<
+	GREP -qFx 'cc -fpic -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF libbar.so-bar.d) -c -o libbar.so-bar.o $(ZMK.test.OutOfTreeSourcePath)bar.c' <$<
 	# Links objects together
 	GREP -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<
+	GREP -qFx 'cc -shared -Wl,-soname=libbar.so -o libbar.so libbar.so-bar.o' <$<
 	# And provides the .so alias
 	GREP -qFx 'ln -sf libfoo.so.1 libfoo.so' <$<
 install-destdir: install-destdir.log

--- a/tests/ObjectGroup/Test.mk
+++ b/tests/ObjectGroup/Test.mk
@@ -13,12 +13,12 @@ $(eval $(ZMK.isolateHostToolchain))
 
 build: build.log
 	# C/C++/ObjC object files can be built.
-	GREP -qFx 'cc -MMD -c -o group1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
-	GREP -qFx 'c++ -MMD -c -o group2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
-	GREP -qFx 'cc -MMD -c -o group3-main.o $(ZMK.test.OutOfTreeSourcePath)main.m' <$<
-	GREP -qFx 'c++ -MMD -c -o group4-main.o $(ZMK.test.OutOfTreeSourcePath)main.cxx' <$<
-	GREP -qFx 'c++ -MMD -c -o group5-main.o $(ZMK.test.OutOfTreeSourcePath)main.cc' <$<
-	GREP -qFx 'cc -MMD -c -o src/group6-main.o $(ZMK.test.OutOfTreeSourcePath)src/main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF group1-main.d) -c -o group1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF group2-main.d) -c -o group2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF group3-main.d) -c -o group3-main.o $(ZMK.test.OutOfTreeSourcePath)main.m' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF group4-main.d) -c -o group4-main.o $(ZMK.test.OutOfTreeSourcePath)main.cxx' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF group5-main.d) -c -o group5-main.o $(ZMK.test.OutOfTreeSourcePath)main.cc' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF src/group6-main.d) -c -o src/group6-main.o $(ZMK.test.OutOfTreeSourcePath)src/main.c' <$<
 
 clean: clean.log
 	# C/C++/ObjC object files can be cleaned.

--- a/tests/Program/Test.mk
+++ b/tests/Program/Test.mk
@@ -13,17 +13,17 @@ $(eval $(ZMK.isolateHostToolchain))
 
 all: all.log
 	# C/C++/ObjC programs can be built.
-	GREP -qFx 'cc -MMD -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog1-main.d) -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
 	GREP -qFx 'cc -o prog1 prog1-main.o' <$<
-	GREP -qFx 'c++ -MMD -c -o prog2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
-	GREP -qFx 'c++ -MMD -o prog2 prog2-main.o' <$<
-	GREP -qFx 'cc -MMD -c -o prog3-main.o $(ZMK.test.OutOfTreeSourcePath)main.m' <$<
-	GREP -qFx 'cc -MMD -o prog3 prog3-main.o -lobjc' <$<
-	GREP -qFx 'c++ -MMD -c -o prog4-main.o $(ZMK.test.OutOfTreeSourcePath)main.cxx' <$<
-	GREP -qFx 'c++ -MMD -o prog4 prog4-main.o' <$<
-	GREP -qFx 'c++ -MMD -c -o prog5-main.o $(ZMK.test.OutOfTreeSourcePath)main.cc' <$<
-	GREP -qFx 'c++ -MMD -o prog5 prog5-main.o' <$<
-	GREP -qFx 'cc -MMD -c -o src/prog6-main.o $(ZMK.test.OutOfTreeSourcePath)src/main.c' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog2-main.d) -c -o prog2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
+	GREP -qFx 'c++ -o prog2 prog2-main.o' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog3-main.d) -c -o prog3-main.o $(ZMK.test.OutOfTreeSourcePath)main.m' <$<
+	GREP -qFx 'cc -o prog3 prog3-main.o -lobjc' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog4-main.d) -c -o prog4-main.o $(ZMK.test.OutOfTreeSourcePath)main.cxx' <$<
+	GREP -qFx 'c++ -o prog4 prog4-main.o' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog5-main.d) -c -o prog5-main.o $(ZMK.test.OutOfTreeSourcePath)main.cc' <$<
+	GREP -qFx 'c++ -o prog5 prog5-main.o' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF src/prog6-main.d) -c -o src/prog6-main.o $(ZMK.test.OutOfTreeSourcePath)src/main.c' <$<
 	GREP -qFx 'cc -o prog6 src/prog6-main.o' <$<
 install: install.log
 	# C/C++/ObjC programs can be installed.
@@ -68,10 +68,10 @@ t:: all-exe
 all-exe.log: ZMK.makeOverrides += exe=.exe
 all-exe: all-exe.log
 	# C/C++ programs respect the .exe suffix (during building)
-	GREP -qFx 'cc -MMD -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog1-main.d) -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
 	GREP -qFx 'cc -o prog1.exe prog1-main.o' <$<
-	GREP -qFx 'c++ -MMD -c -o prog2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
-	GREP -qFx 'c++ -MMD -o prog2.exe prog2-main.o' <$<
+	GREP -qFx 'c++ -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog2-main.d) -c -o prog2-main.o $(ZMK.test.OutOfTreeSourcePath)main.cpp' <$<
+	GREP -qFx 'c++ -o prog2.exe prog2-main.o' <$<
 
 
 t:: install-custom-install-name
@@ -106,7 +106,7 @@ t:: install-program-prefix
 install-program-prefix.log: ZMK.makeOverrides += Configure.ProgramPrefix=prefix-
 install-program-prefix: install-program-prefix.log
 	# Configured program prefix is used during the install phase.
-	GREP -qFx 'cc -MMD -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog1-main.d) -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
 	GREP -qFx 'cc -o prog1 prog1-main.o' <$<
 	GREP -qFx 'install -m 0755 prog1 /usr/local/bin/prefix-prog1' <$<
 
@@ -114,7 +114,7 @@ t:: install-program-suffix
 install-program-suffix.log: ZMK.makeOverrides += Configure.ProgramSuffix=-suffix
 install-program-suffix: install-program-suffix.log
 	# Configured program suffix is used during the install phase.
-	GREP -qFx 'cc -MMD -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog1-main.d) -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
 	GREP -qFx 'cc -o prog1 prog1-main.o' <$<
 	GREP -qFx 'install -m 0755 prog1 /usr/local/bin/prog1-suffix' <$<
 
@@ -122,7 +122,7 @@ t:: install-program-transform-name
 install-program-transform-name.log: ZMK.makeOverrides += Configure.ProgramTransformName=s/prog1/potato/g
 install-program-transform-name: install-program-transform-name.log
 	# Configured program transform expression is applied during the install phase.
-	GREP -qFx 'cc -MMD -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
+	GREP -qFx 'cc -MMD$(if $(ZMK.test.IsOutOfTreeBuild), -MF prog1-main.d) -c -o prog1-main.o $(ZMK.test.OutOfTreeSourcePath)main.c' <$<
 	GREP -qFx 'cc -o prog1 prog1-main.o' <$<
 	GREP -qFx 'install -m 0755 prog1 /usr/local/bin/potato' <$<
 

--- a/zmk/Toolchain.mk
+++ b/zmk/Toolchain.mk
@@ -89,7 +89,7 @@ endif
 # If dependency tracking is enabled, pass extra options to the compiler, to
 # generate dependency data at the same time as compiling object files.
 ifneq (,$(and $(Toolchain.DependencyTracking),$(or $(Toolchain.IsGcc),$(Toolchain.IsClang))))
-CPPFLAGS += -MMD
+%.o: CPPFLAGS += -MMD$(if $(ZMK.IsOutOfTreeBuild), -MF $(@:.o=.d))
 $(if $(Toolchain.debug),$(info DEBUG: compiling object files will generate make dependency information))
 endif
 


### PR DESCRIPTION
When an out-of-tree build with read-only source tree was attempted
ZMK would ask gcc to generate dependency information by passing the
option -MMD, which works fine in in-tree builds as the dependency
files are placed alongside the source.

When the source tree is read-only this would obviously fail. To address
that, conditionally pass -MF to put dependency data alongside object files

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>