### PR TITLE
Fix builds that explicitly use $(ZMK.OutOfTreeSourcePath)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Changes in the next release:
   file paths no longer fail by attempting to put the generated dependency
   information alongside the source code.
 
+* Out-of-tree builds when the original project uses $(ZMK.OutOfTreeSourcePath),
+  explicitly, for example to use the $(wildcard) function, no longer fail.
+
 Backwards incompatible changes in 0.4:
 
 * The Configure module introduces a backwards incompatible change in the

--- a/zmk/ObjectGroup.mk
+++ b/zmk/ObjectGroup.mk
@@ -21,31 +21,44 @@ $(eval $(call ZMK.Import,OS))
 # $1 is the object group name
 # $2 is the source file (path)name
 define ObjectGroup.COMPILE.c
-$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $(CURDIR)/$$(dir $2)
+$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $$(patsubst %/,%,$$(CURDIR)/$$(dir $2))
 	$$(call Silent.Say,CC,$$@)
 	$$(Silent.Command)$$(strip $$(COMPILE.c) -o $$@ $$<)
 endef
 define ObjectGroup.COMPILE.cc
-$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $(CURDIR)/$$(dir $2)
+$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $$(patsubst %/,%,$$(CURDIR)/$$(dir $2))
 	$$(call Silent.Say,CXX,$$@)
 	$$(Silent.Command)$$(strip $$(COMPILE.cc) -o $$@ $$<)
 endef
 define ObjectGroup.COMPILE.m
-$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $(CURDIR)/$$(dir $2)
+$$(dir $2)$1-$$(basename $$(notdir $2)).o: $$(ZMK.OutOfTreeSourcePath)$2 | $$(patsubst %/,%,$$(CURDIR)/$$(dir $2))
 	$$(call Silent.Say,OBJC,$$@)
 	$$(Silent.Command)$$(strip $$(COMPILE.m) -o $$@ $$<)
 endef
 
 ObjectGroup.Variables=Sources Objects ObjectsC ObjectsCxx ObjectsObjC
 define ObjectGroup.Template
+# Sources are not re-defined with := so that they can expand lazily.
 $1.Sources ?= $$(error define $1.Sources - the list of source files to compile)
-$1.sourcesC = $$(filter %.c,$$($1.Sources))
-$1.sourcesCxx = $$(filter %.cpp %.cxx %.cc,$$($1.Sources))
-$1.sourcesObjc = $$(filter %.m,$$($1.Sources))
+# NOTE: Strip out the out-of-tree-source-path so that all the $1.sources (note
+# the lower-case) variables use source-relative paths. This is important when
+# we want to derive object paths using source paths (same file with .o
+# extension replaced but rooted at the build tree, not the source tree). When
+# ZMK needs to support generated source files this should be changed.
+$1.sources = $$(patsubst $$(ZMK.OutOfTreeSourcePath)%,%,$$($1.Sources))
+
+$1.sourcesC = $$(filter %.c,$$($1.sources))
+$1.sourcesCxx = $$(filter %.cpp %.cxx %.cc,$$($1.sources))
+$1.sourcesObjC = $$(filter %.m,$$($1.sources))
+
+# Object files contain the object group name prepndend to the file name and the extension replaced with .o
 $1.ObjectsC ?= $$(foreach src,$$($1.sourcesC),$$(dir $$(src))$1-$$(basename $$(notdir $$(src))).o)
 $1.ObjectsCxx ?= $$(foreach src,$$($1.sourcesCxx),$$(dir $$(src))$1-$$(basename $$(notdir $$(src))).o)
-$1.ObjectsObjC ?= $$(foreach src,$$($1.sourcesObjc),$$(dir $$(src))$1-$$(basename $$(notdir $$(src))).o)
+$1.ObjectsObjC ?= $$(foreach src,$$($1.sourcesObjC),$$(dir $$(src))$1-$$(basename $$(notdir $$(src))).o)
+
 $1.Objects ?= $$(strip $$($1.ObjectsC) $$($1.ObjectsCxx) $$($1.ObjectsObjC))
+
+# Suggested linger depends on the cardinality of variou types of objects.
 $1.SuggestedLinkerSymbol ?= $$(if $$($1.ObjectsObjC),OBJCLD,$$(if $$($1.ObjectsCxx),CXXLD,CCLD))
 
 # Check if we have the required compiler.
@@ -55,9 +68,9 @@ $$(if $$($1.ObjectsCxx),$$(if $$(Toolchain.CXX.IsAvailable),,$$(error Building $
 # This is how to compile each specific source file.
 $$(foreach src,$$($1.sourcesC),$$(eval $$(call ObjectGroup.COMPILE.c,$1,$$(src))))
 $$(foreach src,$$($1.sourcesCxx),$$(eval $$(call ObjectGroup.COMPILE.cc,$1,$$(src))))
-$$(foreach src,$$($1.sourcesObjc),$$(eval $$(call ObjectGroup.COMPILE.m,$1,$$(src))))
+$$(foreach src,$$($1.sourcesObjC),$$(eval $$(call ObjectGroup.COMPILE.m,$1,$$(src))))
 # Create all support directories for out-of-tree builds
-$$(foreach d,$$(filter-out ./,$$(sort $$(dir $$($1.Sources)))),$$(eval $$(call ZMK.Expand,Directory,$$(CURDIR)/$$d)))
+$$(foreach d,$$(patsubst %/,%,$$(addprefix $$(CURDIR)/,$$(filter-out ./,$$(sort $$(dir $$($1.sources)))))),$$(eval $$(call ZMK.Expand,Directory,$$d)))
 
 ifneq (,$$($1.Objects))
 clean::


### PR DESCRIPTION
When a project uses out-of-tree source path explicitly, for example
to use it in conjunction with $(wildcard), current logic for out-of-tree
builds would not work correctly. There are several related issues
but the new logic seems to de-compose everything correctly now.

The main fix is the creation of $1.sources which is just $1.Sources
with the out-of-tree source prefix stripped. Subsequently, all objects
are defined with the stripped path.

As a small optimization, the order-only dependency on the directory that
contains object files automatically strips the trailing slash, avoiding
extra rules that cost some time.

Lastly fix typo in internal variable name, $1.sourcesObjC now capitalizes
the trailing C correctly.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>