### PR TITLE
Fix clang detection on FreeBSD, add initial integration test suite

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,7 +73,7 @@ $(ZMK.releaseArchive).Files += $(addprefix tests/OS/,Makefile Test.mk)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Program/,Makefile Test.mk main.c main.cpp main.m main.cxx main.cc src/main.c)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Symlink/,Makefile Test.mk)
 $(ZMK.releaseArchive).Files += $(addprefix tests/Tarball.Src/,Makefile Test.mk foo.txt home/alice/.gnupg/fake-gpg-data home/bob/.gitkeep home/eve/.gnupg/fake-gpg-data)
-$(ZMK.releaseArchive).Files += $(addprefix tests/Toolchain/,Makefile Test.mk)
+$(ZMK.releaseArchive).Files += $(addprefix tests/Toolchain/,Makefile Test.mk integration/Makefile integration/Test.mk)
 $(ZMK.releaseArchive).Files += tests/bin/GREP
 $(eval $(call ZMK.Expand,Tarball.Src,$(ZMK.releaseArchive)))
 

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ Changes in the next release:
 
 * The Toolchain module no longer misidentifies clang on FreeBSD.
 
+* The Toolchain module has initial integration test suite that checks the real
+  interaction with the host system.
+
 Changes in 0.4.2:
 
 * The PVS module no longer fails when running the pvs-report target.

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ Changes in the next release:
 * The Program.Test template no longer fails with syntax error when computing
   test coverage.
 
+* The Toolchain module no longer misidentifies clang on FreeBSD.
+
 Changes in 0.4.2:
 
 * The PVS module no longer fails when running the pvs-report target.

--- a/tests/Toolchain/Test.mk
+++ b/tests/Toolchain/Test.mk
@@ -21,6 +21,8 @@ t:: debug-defaults debug-dependency-tracking \
 %.log: ZMK.makeOverrides += Toolchain.cxx=/usr/bin/host-linux-gnu-g++
 %.log: ZMK.makeOverrides += Toolchain.cxx.dumpmachine=host-linux-gnu
 %.log: ZMK.makeOverrides += Toolchain.g++.dumpmachine=build-linux-gnu
+%.log: ZMK.makeOverrides += Toolchain.cc.version=
+%.log: ZMK.makeOverrides += Toolchain.cxx.version=
 
 debug-defaults: debug-defaults.log
 	# By default CC=cc and CXX is either c++ or g++.

--- a/tests/Toolchain/integration/Makefile
+++ b/tests/Toolchain/integration/Makefile
@@ -1,0 +1,6 @@
+include z.mk
+
+$(eval $(call ZMK.Import,Toolchain))
+
+.PHONY: debug
+debug: ;

--- a/tests/Toolchain/integration/Test.mk
+++ b/tests/Toolchain/integration/Test.mk
@@ -1,0 +1,32 @@
+#!/usr/bin/make -f
+include zmk/internalTest.mk
+
+t:: integration 
+
+# Test logs will contain debugging messages
+%.log: ZMK.makeOverrides += DEBUG=toolchain
+
+integration: integration.log
+ifeq ($(ZMK.test.OSRelease.ID),freebsd)
+	GREP -qFx 'DEBUG: Toolchain.CC.ImageFormat=ELF' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsAvailable=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsClang=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsCross=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsGcc=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsTcc=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CC.IsWatcom=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.ImageFormat=ELF' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.IsAvailable=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.IsClang=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.IsCross=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.IsGcc=' <$<
+	GREP -qFx 'DEBUG: Toolchain.CXX.IsWatcom=' <$<
+	GREP -qFx 'DEBUG: Toolchain.DependencyTracking=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.ImageFormat=ELF' <$<
+	GREP -qFx 'DEBUG: Toolchain.IsClang=yes' <$<
+	GREP -qFx 'DEBUG: Toolchain.IsCross=' <$<
+	GREP -qFx 'DEBUG: Toolchain.IsGcc=' <$<
+	GREP -qFx 'DEBUG: Toolchain.IsWatcom=' <$<
+	GREP -qFx 'DEBUG: Toolchain.cc=/usr/bin/cc' <$<
+	GREP -qFx 'DEBUG: Toolchain.cxx=/usr/bin/c++' <$<
+endif

--- a/zmk/Toolchain.mk
+++ b/zmk/Toolchain.mk
@@ -66,15 +66,19 @@ Toolchain.cxx ?= $(shell command -v $(CXX) 2>/dev/null)
 Toolchain.cc := $(if $(findstring $(Toolchain.cc),/usr/bin/cc),$(realpath $(Toolchain.cc)),$(Toolchain.cc))
 Toolchain.cxx := $(if $(findstring $(Toolchain.cxx),/usr/bin/c++ /usr/bin/g++),$(realpath $(Toolchain.cxx)),$(Toolchain.cxx))
 
+# Is the C and C++ compiler really available?
+Toolchain.CC.IsAvailable ?= $(if $(wildcard $(realpath $(Toolchain.cc))),yes)
+Toolchain.CXX.IsAvailable ?= $(if $(wildcard $(realpath $(Toolchain.cxx))),yes)
+
+# What is the version string of the C and the C++ compilers?
+Toolchain.cc.version ?= $(if $(Toolchain.CC.IsAvailable),$(shell $(Toolchain.cc) --version))
+Toolchain.cxx.version ?= $(if $(Toolchain.CXX.IsAvailable),$(shell $(Toolchain.cxx) --version))
+
 # Import toolchain-specific knowledge.
 $(eval $(call ZMK.Import,toolchain.GCC))
 $(eval $(call ZMK.Import,toolchain.Clang))
 $(eval $(call ZMK.Import,toolchain.Watcom))
 $(eval $(call ZMK.Import,toolchain.Tcc))
-
-# Is the C and C++ compiler really available?
-Toolchain.CC.IsAvailable ?= $(if $(wildcard $(realpath $(Toolchain.cc))),yes)
-Toolchain.CXX.IsAvailable ?= $(if $(wildcard $(realpath $(Toolchain.cxx))),yes)
 
 # Is either the C or C++ compiler a cross compiler?
 Toolchain.IsCross ?= $(or $(Toolchain.CC.IsCross),$(Toolchain.CXX.IsCross))

--- a/zmk/internalTest.mk
+++ b/zmk/internalTest.mk
@@ -53,6 +53,35 @@ ZMK.makeOverrides += ZMK.testing=yes
 # For default logic, see the rule below.
 ZMK.makeTarget ?=
 
+ifeq ($(origin OS),environment)
+OS.test.Kernel = $(findstring $(OS),Windows_NT)
+else
+OS.test.Kernel := $(shell uname -s)
+endif
+
+# Read a file from disk. Ideally we'd use $(file <) but it doens't have a
+# feature flag to check for and widely used systems do not support reading.
+ZMK.test.readFile=$(shell cat "$1")
+# Pick a key from a string with key=value pairs
+ZMK.test.valueOfKey=$(strip $(patsubst $2=%,%,$(filter $2=%,$1)))
+
+# Use real os-release(5) information if available or synthesize minimal placeholder.
+ifneq (,$(findstring $(OS.test.Kernel),Linux FreeBSD NetBSD OpenBSD GNU GNU/kFreeBSD SunOS Haiku))
+ZMK.test.OSRelease=$(or $(call ZMK.test.readFile,/etc/os-release),$(error zmk integration tests depends on /etc/os-release))
+endif
+ifeq ($(OS.test.Kernel),Darwin)
+ZMK.test.OSRelease=ID=macos VERSION_ID=$(word 2,$(shell sysctl kern.osproductversion))
+endif
+ifeq ($(OS.test.Kernel),Windows_NT)
+ZMK.test.OSRelease=ID=windows VERSION_ID=zmk-unimplemented
+endif
+
+# The full text of os-release(5) file.
+# The ID field from the os-release(5) file.
+ZMK.test.OSRelease.ID=$(call ZMK.test.valueOfKey,$(ZMK.test.OSRelease),ID)
+# The VERSION_ID field from the os-release(5) file.
+ZMK.test.OSRelease.VERSION_ID=$(call ZMK.test.valueOfKey,$(ZMK.test.OSRelease),VERSION_ID)
+
 # Tests print a header, unless silent mode is used
 # Tests do not use localization
 # Tests always remake targets

--- a/zmk/internalTest.mk
+++ b/zmk/internalTest.mk
@@ -9,13 +9,18 @@ t::
 # This shields the test from whatever is installed on the host.
 define ZMK.isolateHostToolchain
 %.log: ZMK.makeOverrides += Toolchain.CC.IsAvailable=yes
-%.log: ZMK.makeOverrides += Toolchain.CXX.IsAvailable=yes
+%.log: ZMK.makeOverrides += Toolchain.CC.IsClang=
 %.log: ZMK.makeOverrides += Toolchain.CC.IsGcc=yes
+%.log: ZMK.makeOverrides += Toolchain.CXX.IsAvailable=yes
+%.log: ZMK.makeOverrides += Toolchain.CXX.IsClang=
 %.log: ZMK.makeOverrides += Toolchain.CXX.IsGcc=yes
+%.log: ZMK.makeOverrides += Toolchain.IsClang=
 %.log: ZMK.makeOverrides += Toolchain.cc.dumpmachine=
-%.log: ZMK.makeOverrides += Toolchain.gcc.dumpmachine=
+%.log: ZMK.makeOverrides += Toolchain.cc.version=
 %.log: ZMK.makeOverrides += Toolchain.cxx.dumpmachine=
+%.log: ZMK.makeOverrides += Toolchain.cxx.version=
 %.log: ZMK.makeOverrides += Toolchain.g++.dumpmachine=
+%.log: ZMK.makeOverrides += Toolchain.gcc.dumpmachine=
 endef
 
 # Find the path of the zmk installation

--- a/zmk/toolchain.Clang.mk
+++ b/zmk/toolchain.Clang.mk
@@ -1,5 +1,5 @@
 # Are we using Clang?
-Toolchain.CC.IsClang=$(if $(findstring clang,$(Toolchain.cc)),yes)
-Toolchain.CXX.IsClang=$(if $(findstring clang,$(Toolchain.cxx)),yes)
-Toolchain.IsClang=$(and $(Toolchain.CC.IsClang),$(Toolchain.CXX.IsClang))
+Toolchain.CC.IsClang?=$(if $(or $(findstring clang,$(Toolchain.cc)),$(findstring clang,$(Toolchain.cc.version))),yes)
+Toolchain.CXX.IsClang?=$(if $(or $(findstring clang,$(Toolchain.cxx)),$(findstring clang,$(Toolchain.cxx.version))),yes)
+Toolchain.IsClang?=$(and $(Toolchain.CC.IsClang),$(Toolchain.CXX.IsClang))
 # TODO: handle cross compiling with clang.


### PR DESCRIPTION
Comment from an embedded patch:

    Add initial integration test for Toolchain module
    
    Integration tests use the same Test.mk infrastructure shared by existing unit
    tests. Unlike them, system mocking is *NOT* performed. There's some additional
    infrastructure for integration tests. Initially they depend on os-release(5)
    for information about which canned behavior to expect. Over time this may
    change, initially it is appropriate, as compiler detection is tricky and
    checking what was detected this way is easy. This may change once the
    compile-time Probe system is implemented.
    
    The toolchain module now contains checks for FreeBSD. It was verified on
    FreeBSD 12.2 running on x86_64. Currently there is no CI for FreeBSD systems.
