### PR TITLE
Add support for Configure.TargetArchTriplet

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,10 @@ Changes in the next release:
   the build system (e.g. to pass -fpic) as make treats command line overrides
   differently from environment values.
 
+* The Configure module now supports setting the target triplet. The generated
+  configuration script handles the --target= command line option and the result
+  is available as $(Configure.TargetArchTriplet).
+
 Changes in 0.4.2:
 
 * The PVS module no longer fails when running the pvs-report target.

--- a/man/zmk.Configure.5.in
+++ b/man/zmk.Configure.5.in
@@ -101,6 +101,16 @@ named
 and
 .Em $(Configure.HostArchTriplet)-g++
 for the C and C++ compilers, respectively.
+.Ss Configure.TargetArchTriplet
+This variable is set by the
+.Nm configure
+script when invoked with the
+.Em --target=...
+option. It represents the
+.Em triplet
+describing the system for which any generated code will be made. This variable
+is needed infrequently, usually by tools such as compilers, to prepare them for
+creating binary code for a given architecture.
 .Ss Configure.DependencyTracking
 This variable is controlled by the
 .Nm configure

--- a/tests/Configure/Test.mk
+++ b/tests/Configure/Test.mk
@@ -10,6 +10,7 @@ t:: \
 	config-defaults \
 	config-build \
 	config-host \
+	config-target \
 	config-enable-dependency-tracking \
 	config-disable-dependency-tracking \
 	config-enable-maintainer-mode \
@@ -71,6 +72,7 @@ debug-defaults: debug-defaults.log
 	# Note that here we also measure the default values of an un-configured build.
 	GREP -qFx 'DEBUG: Configure.HostArchTriplet=' <$<
 	GREP -qFx 'DEBUG: Configure.BuildArchTriplet=' <$<
+	GREP -qFx 'DEBUG: Configure.TargetArchTriplet=' <$<
 	GREP -qFx 'DEBUG: Configure.DependencyTracking=yes' <$<
 	GREP -qFx 'DEBUG: Configure.MaintainerMode=yes' <$<
 	GREP -qFx 'DEBUG: Configure.SilentRules=' <$<
@@ -94,6 +96,7 @@ config-defaults: config.defaults.mk
 	# Note the lack of whole-line matching (-x).
 	GREP -v -qF 'Configure.BuildArchTriplet=' <$<
 	GREP -v -qF 'Configure.HostArchTriplet=' <$<
+	GREP -v -qF 'Configure.TargetArchTriplet=' <$<
 	GREP -v -qF 'Configure.DependencyTracking=' <$<
 	GREP -v -qF 'Configure.MaintainerMode=' <$<
 	GREP -v -qF 'Configure.SilentRules=' <$<
@@ -112,6 +115,12 @@ config-host: config.host.mk
 	# configure --host= sets Configure.HostArchTriplet
 	GREP -qFx 'Configure.HostArchTriplet=foo-linux-gnu' <$<
 	GREP -qFx 'Configure.Options=$(if $(ZMK.test.IsOutOfTreeBuild),ZMK.SrcDir=$(ZMK.test.SrcDir) )--host=foo-linux-gnu' <$<
+
+config.target.mk: configureOptions += --target=foo-linux-gnu
+config-target: config.target.mk
+	# configure --target= sets Configure.TargetArchTriplet
+	GREP -qFx 'Configure.TargetArchTriplet=foo-linux-gnu' <$<
+	GREP -qFx 'Configure.Options=$(if $(ZMK.test.IsOutOfTreeBuild),ZMK.SrcDir=$(ZMK.test.SrcDir) )--target=foo-linux-gnu' <$<
 
 config.enable-dependency-tracking.mk: configureOptions += --enable-dependency-tracking
 config-enable-dependency-tracking: config.enable-dependency-tracking.mk

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -22,6 +22,7 @@ Configure.debug ?= $(findstring configure,$(DEBUG))
 # Configuration system defaults, also changed by GNUmakefile.configure.mk
 Configure.HostArchTriplet ?=
 Configure.BuildArchTriplet ?=
+Configure.TargetArchTriplet ?=
 Configure.DependencyTracking ?= yes
 Configure.MaintainerMode ?= yes
 Configure.SilentRules ?=
@@ -80,6 +81,7 @@ while [ "$$#" -ge 1 ]; do
             echo "Compilation options:"
             echo "  --build=GNU_TRIPLET         Describe the build machine with the given GNU_TRIPLET"
             echo "  --host=GNU_TRIPLET          Describe the host machine with the given GNU_TRIPLET"
+            echo "  --target=GNU_TRIPLET        Describe the target machine with the given GNU_TRIPLET"
             echo "  --enable-dependency-tracking"
             echo "                              Track dependencies between files (implicit)"
             echo "  --disable-dependency-tracking"
@@ -148,6 +150,7 @@ while [ "$$#" -ge 1 ]; do
     case "$$1" in
         --build=*)                      buildArchTriplet="$$(rhs "$$1")" && shift ;;
         --host=*)                       hostArchTriplet="$$(rhs "$$1")" && shift ;;
+        --target=*)                     targetArchTriplet="$$(rhs "$$1")" && shift ;;
 
         --enable-dependency-tracking)   dependencyTracking=yes && shift ;;
         --disable-dependency-tracking)  dependencyTracking=no && shift ;;
@@ -213,6 +216,7 @@ done
     echo "# Note that those impact compiler selection unless CC and CXX are overridden."
     test -n "$${buildArchTriplet:-}"    && echo "Configure.BuildArchTriplet=$$buildArchTriplet"     || echo "#   Configure.BuildArchTriplet was not specified."
     test -n "$${hostArchTriplet:-}"     && echo "Configure.HostArchTriplet=$$hostArchTriplet"       || echo "#   Configure.HostArchTriplet was not specified."
+    test -n "$${targetArchTriplet:-}"   && echo "Configure.TargetArchTriplet=$$targetArchTriplet"   || echo "#   Configure.TargetArchTriplet was not specified."
     echo
     echo "# Build-time configuration of application directories."
     test -n "$${prefix:-}"          && echo "prefix=$$prefix"                   || echo "#   prefix was not specified."


### PR DESCRIPTION
This extends to the configure script which now accepts, and stores, --target=,
for improved compatibility with autotools.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>