### PR TITLE
Generate zmk dist archive with -, not _

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,7 +62,7 @@ man/%: man/%.in | $(CURDIR)/man
 $(foreach f,$(ZMK.manPages),$(eval $(call ZMK.Expand,ManPage,man/$f)))
 
 # Build the release tarball.
-ZMK.releaseArchive?=$(NAME)_$(VERSION).tar.gz
+ZMK.releaseArchive?=$(NAME)-$(VERSION).tar.gz
 $(ZMK.releaseArchive).Files = GNUmakefile README.md LICENSE NEWS
 $(ZMK.releaseArchive).Files += $(addsuffix .in,$(addprefix man/,$(ZMK.manPages)))
 $(ZMK.releaseArchive).Files += $(addprefix examples/hello-c/,Makefile Test.mk hello.c)


### PR DESCRIPTION
The generated distribution archive usually has a single directory
$name-$version but because Debian packaging normalizes this, and I never
noticed, the one used by zmk was always $name_version. This causes some
friction with packaging for Yocto and Fedora, where non-default overrides are
required.

Fortunately it's just a single character fix.

Fixes: https://github.com/zyga/zmk/issues/62
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>