### PR TITLE
Treat --exec_prefix= like --exec-prefix=

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,9 @@ Changes in the next release:
   configuration script handles the --target= command line option and the result
   is available as $(Configure.TargetArchTriplet).
 
+* The configure script now accepts --exec_prefix= as an alternate spelling of
+  --exec-prefix.
+
 Changes in 0.4.2:
 
 * The PVS module no longer fails when running the pvs-report target.

--- a/tests/Configure/Test.mk
+++ b/tests/Configure/Test.mk
@@ -21,6 +21,8 @@ t:: \
 	config-program-suffix \
 	config-program-transform-name \
 	config-prefix \
+	config-exec-prefix \
+	config-exec_prefix \
 	config-bindir \
 	config-sbindir \
 	config-libdir \
@@ -175,6 +177,11 @@ config-prefix: config.prefix.mk
 config.exec-prefix.mk: configureOptions += --exec-prefix=/foo
 config-exec-prefix: config.exec-prefix.mk
 	# configure --exec-prefix=/foo sets exec_prefix=/foo
+	GREP -qFx 'exec_prefix=/foo' <$<
+
+config.exec_prefix.mk: configureOptions += --exec_prefix=/foo
+config-exec_prefix: config.exec_prefix.mk
+	# configure --exec_prefix=/foo sets exec_prefix=/foo
 	GREP -qFx 'exec_prefix=/foo' <$<
 
 dirs=bindir sbindir libdir libexecdir includedir mandir infodir sysconfdir datadir localstatedir runstatedir sharedstatedir

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -92,6 +92,7 @@ while [ "$$#" -ge 1 ]; do
             echo "Build-time directory selection:"
             echo "  --prefix=PREFIX             Set prefix for all directories to PREFIX"
             echo "  --exec-prefix=PREFIX        Set prefix for libraries and programs to PREFIX"
+            echo "  --exec_prefix=PREFIX        Alternate spelling --exec-prefix"
             echo
             echo "  --bindir=DIR                Install user programs to DIR"
             echo "  --sbindir=DIR               Install super-user programs to DIR"
@@ -168,7 +169,7 @@ while [ "$$#" -ge 1 ]; do
         --program-suffix=*)             programSuffix="$$(rhs "$$1")" && shift ;;
         --program-transform-name=*)     programTransformName="$$(rhs "$$1")" && shift ;;
 
-        --exec-prefix=*)                exec_prefix="$$(rhs "$$1")" && shift ;;
+        --exec-prefix=*|--exec_prefix=*)exec_prefix="$$(rhs "$$1")" && shift ;;
         --prefix=*)                     prefix="$$(rhs "$$1")" && shift ;;
 
         --bindir=*)                     bindir="$$(rhs "$$1")" && shift ;;


### PR DESCRIPTION
Debian is passing --exec-prefix=, but yocto is using --exec_prefix=.
Autotools handles both exactly the same way so let's do that as well.

This also fixes tests for exec-prefix that were present but not invoked.

Fixes: https://github.com/zyga/zmk/issues/67
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>