### PR TITLE
Add support for --{enable,disable}-{static,dynamic}

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,6 +29,9 @@ ZMK.manPages = \
 	zmk.Configure.5 \
 	zmk.Coverity.5 \
 	zmk.Directories.5 \
+	zmk.Library.A.5 \
+	zmk.Library.DyLib.5 \
+	zmk.Library.So.5 \
 	zmk.OS.5 \
 	zmk.Program.5 \
 	zmk.Script.5 \

--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,12 @@ Changes in the next release:
   configuration script handles the --target= command line option and the result
   is available as $(Configure.TargetArchTriplet).
 
+* The Configure module now supports configuration of static and dynamic
+  libraries with the new configuration script options: --enable-static,
+  --disable-static, --enable-dynamic and --disable-dynamic. Both library types
+  are enabled by default. The values are stored and inhibit expansion of
+  appropriate templates.
+
 Changes in 0.4.2:
 
 * The PVS module no longer fails when running the pvs-report target.

--- a/man/zmk.Configure.5.in
+++ b/man/zmk.Configure.5.in
@@ -151,6 +151,28 @@ and
 (default). When enabled it expands to
 .Em yes
 and silences make rules defined by zmk.
+.Ss Configure.StaticLibraries
+This variable is controlled by the
+.Nm configure
+script options
+.Em --enable-static
+(default) and
+.Em --disable-static .
+When static libraries are disabled the template
+.Nm Library.A
+becomes inactive.
+.Ss Configure.DynamicLibraries
+This variable is controlled by the
+.Nm configure
+script options
+.Em --enable-dynamic
+(default) and
+.Em --disable-dynamic .
+When dynamic libraries are disabled the templates
+.Nm Library.So
+and
+.Nm Library.DyLib
+become inactive.
 .Ss Configure.ProgramPrefix
 This variable is set by the
 .Nm configure

--- a/man/zmk.Library.A.5.in
+++ b/man/zmk.Library.A.5.in
@@ -1,0 +1,27 @@
+.Dd Feb 2, 2021
+.Os zmk @VERSION@
+.Dt zmk.Library.A 5 PRM
+.Sh NAME
+.Nm Library.A
+.Nd template for compiling C/C++/ObjC static libraries
+.Sh SYNOPSIS
+.Bd -literal
+include z.mk
+
+# libName is any valid identifier.
+libName.a.Sources = hello.c
+$(eval $(call ZMK.Expand,Library.A,libName.a))
+.Ed
+.Sh DESCRIPTION
+This manual page is a stub.
+.Pp
+When
+.Nm configure
+script is invoked with
+.Em --disable-static
+then this template behaves as if it was empty.
+.Sh TARGETS
+.Sh VARIABLES
+.Sh HISTORY
+.Sh AUTHORS
+.An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zmk.Library.DyLib.5.in
+++ b/man/zmk.Library.DyLib.5.in
@@ -1,0 +1,27 @@
+.Dd Feb 2, 2021
+.Os zmk @VERSION@
+.Dt zmk.Library.DyLib 5 PRM
+.Sh NAME
+.Nm Library.So
+.Nd template for compiling C/C++/ObjC shared Mach-O libraries
+.Sh SYNOPSIS
+.Bd -literal
+include z.mk
+
+# libName is any valid identifier.
+libName.dylib.Sources = hello.c
+$(eval $(call ZMK.Expand,Library.DyLib,libName.dylib))
+.Ed
+.Sh DESCRIPTION
+This manual page is a stub.
+.Pp
+When
+.Nm configure
+script is invoked with
+.Em --disable-shared
+then this template behaves as if it was empty.
+.Sh TARGETS
+.Sh VARIABLES
+.Sh HISTORY
+.Sh AUTHORS
+.An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zmk.Library.So.5.in
+++ b/man/zmk.Library.So.5.in
@@ -1,0 +1,27 @@
+.Dd Feb 2, 2021
+.Os zmk @VERSION@
+.Dt zmk.Library.So 5 PRM
+.Sh NAME
+.Nm Library.So
+.Nd template for compiling C/C++/ObjC shared ELF libraries
+.Sh SYNOPSIS
+.Bd -literal
+include z.mk
+
+# libName is any valid identifier.
+libName.so.Sources = hello.c
+$(eval $(call ZMK.Expand,Library.So,libName.so))
+.Ed
+.Sh DESCRIPTION
+This manual page is a stub.
+.Pp
+When
+.Nm configure
+script is invoked with
+.Em --disable-shared
+then this template behaves as if it was empty.
+.Sh TARGETS
+.Sh VARIABLES
+.Sh HISTORY
+.Sh AUTHORS
+.An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/tests/Configure/Test.mk
+++ b/tests/Configure/Test.mk
@@ -17,6 +17,10 @@ t:: \
 	config-disable-maintainer-mode \
 	config-enable-silent-rules \
 	config-disable-silent-rules \
+	config-enable-static \
+	config-disable-static \
+	config-enable-dynamic \
+	config-disable-dynamic \
 	config-program-prefix \
 	config-program-suffix \
 	config-program-transform-name \
@@ -76,6 +80,8 @@ debug-defaults: debug-defaults.log
 	GREP -qFx 'DEBUG: Configure.DependencyTracking=yes' <$<
 	GREP -qFx 'DEBUG: Configure.MaintainerMode=yes' <$<
 	GREP -qFx 'DEBUG: Configure.SilentRules=' <$<
+	GREP -qFx 'DEBUG: Configure.StaticLibraries=yes' <$<
+	GREP -qFx 'DEBUG: Configure.DynamicLibraries=yes' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramPrefix=' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramSuffix=' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramTransformName=' <$<
@@ -100,6 +106,8 @@ config-defaults: config.defaults.mk
 	GREP -v -qF 'Configure.DependencyTracking=' <$<
 	GREP -v -qF 'Configure.MaintainerMode=' <$<
 	GREP -v -qF 'Configure.SilentRules=' <$<
+	GREP -v -qF 'Configure.StaticLibraries=' <$<
+	GREP -v -qF 'Configure.DynamicLibraries=' <$<
 	GREP -v -qF 'Configure.ProgramPrefix=' <$<
 	GREP -v -qF 'Configure.ProgramSuffix=' <$<
 	GREP -v -qF 'Configure.ProgramTransformName=' <$<
@@ -151,6 +159,26 @@ config.disable-silent-rules.mk: configureOptions += --disable-silent-rules
 config-disable-silent-rules: config.disable-silent-rules.mk
 	# configure --disable-dependency-tracking sets Configure.SilentRules= (empty but set)
 	GREP -qFx 'Configure.SilentRules=' <$<
+
+config.enable-static.mk: configureOptions += --enable-static
+config-enable-static: config.enable-static.mk
+	# configure --enable-static sets Configure.StaticLibraries=yes
+	GREP -qFx 'Configure.StaticLibraries=yes' <$<
+
+config.disable-static.mk: configureOptions += --disable-static
+config-disable-static: config.disable-static.mk
+	# configure --disable-static sets Configure.StaticLibraries= (empty but set)
+	GREP -qFx 'Configure.StaticLibraries=' <$<
+
+config.enable-dynamic.mk: configureOptions += --enable-dynamic
+config-enable-dynamic: config.enable-dynamic.mk
+	# configure --enable-dynamic sets Configure.DynamicLibraries=yes
+	GREP -qFx 'Configure.DynamicLibraries=yes' <$<
+
+config.disable-dynamic.mk: configureOptions += --disable-dynamic
+config-disable-dynamic: config.disable-dynamic.mk
+	# configure --disable-dynamic sets Configure.DynamicLibraries= (empty but set)
+	GREP -qFx 'Configure.DynamicLibraries=' <$<
 
 config.program-prefix.mk: configureOptions += --program-prefix=awesome-
 config-program-prefix: config.program-prefix.mk

--- a/tests/Library.A/Test.mk
+++ b/tests/Library.A/Test.mk
@@ -16,7 +16,7 @@ $(eval $(ZMK.isolateHostToolchain))
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
 # Some logs behave as if configure --enable-static was used
 %-enable-static-libs.log: ZMK.makeOverrides += Configure.StaticLibraries=yes
-# Some logs behave as if configure --disable -static was used
+# Some logs behave as if configure --disable-static was used
 %-disable-static-libs.log: ZMK.makeOverrides += Configure.StaticLibraries=
 # Test depends on source files
 %.log: foo.c
@@ -100,8 +100,8 @@ clean-destdir: clean-destdir.log
 	GREP -qFx 'rm -f ./libfoo.a-foo.d' <$<
 
 all-enable-static-libs: all-enable-static-libs.log
-    # Configuring --enable-static enables compliation of static libraries.
+	# Configuring --enable-static enables compilation of static libraries.
 	GREP -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<
 all-disable-static-libs: all-disable-static-libs.log
-    # Configuring --disable-static disables compliation of static libraries.
+	# Configuring --disable-static disables compilation of static libraries.
 	GREP -v -qFx 'ar -cr libfoo.a libfoo.a-foo.o' <$<

--- a/tests/Library.DyLib/Test.mk
+++ b/tests/Library.DyLib/Test.mk
@@ -3,13 +3,18 @@
 include zmk/internalTest.mk
 
 t:: all install uninstall clean \
-    all-destdir install-destdir uninstall-destdir clean-destdir
+    all-destdir install-destdir uninstall-destdir clean-destdir \
+    all-enable-dynamic-libs all-disable-dynamic-libs
 
 $(eval $(ZMK.isolateHostToolchain))
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=library.dylib
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
+# Some logs behave as if configure --enable-static was used
+%-enable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=yes
+# Some logs behave as if configure --disable -static was used
+%-disable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=
 # Test depends on source files
 %.log: foo.c
 
@@ -88,3 +93,10 @@ clean-destdir: clean-destdir.log
 	GREP -qFx 'rm -f ./libfoo.1.dylib-foo.d' <$<
 	GREP -qFx 'rm -f ./libbar.dylib-bar.o' <$<
 	GREP -qFx 'rm -f ./libbar.dylib-bar.d' <$<
+
+all-enable-dynamic-libs: all-enable-dynamic-libs.log
+    # Configuring --enable-dynamic enables compliation of dynamic libraries.
+	GREP -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<
+all-disable-dynamic-libs: all-disable-dynamic-libs.log
+    # Configuring --disable-dynamic disables compliation of dynamic libraries.
+	GREP -v -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<

--- a/tests/Library.DyLib/Test.mk
+++ b/tests/Library.DyLib/Test.mk
@@ -11,9 +11,9 @@ $(eval $(ZMK.isolateHostToolchain))
 %.log: ZMK.makeOverrides += DEBUG=library.dylib
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
-# Some logs behave as if configure --enable-static was used
+# Some logs behave as if configure --enable-dynamic was used
 %-enable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=yes
-# Some logs behave as if configure --disable -static was used
+# Some logs behave as if configure --disable-dynamic was used
 %-disable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=
 # Test depends on source files
 %.log: foo.c
@@ -95,8 +95,8 @@ clean-destdir: clean-destdir.log
 	GREP -qFx 'rm -f ./libbar.dylib-bar.d' <$<
 
 all-enable-dynamic-libs: all-enable-dynamic-libs.log
-    # Configuring --enable-dynamic enables compliation of dynamic libraries.
+	# Configuring --enable-dynamic enables compilation of dynamic libraries.
 	GREP -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<
 all-disable-dynamic-libs: all-disable-dynamic-libs.log
-    # Configuring --disable-dynamic disables compliation of dynamic libraries.
+	# Configuring --disable-dynamic disables compilation of dynamic libraries.
 	GREP -v -qFx 'cc -dynamiclib -compatibility_version 1.0 -current_version 1.0 -o libfoo.1.dylib libfoo.1.dylib-foo.o' <$<

--- a/tests/Library.So/Test.mk
+++ b/tests/Library.So/Test.mk
@@ -95,8 +95,8 @@ clean-destdir: clean-destdir.log
 	GREP -qFx 'rm -f ./libbar.so-bar.d' <$<
 
 all-enable-dynamic-libs: all-enable-dynamic-libs.log
-	# Configuring --enable-dynamic enables compliation of dynamic libraries.
+	# Configuring --enable-dynamic enables compilation of dynamic libraries.
 	GREP -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<
 all-disable-dynamic-libs: all-disable-dynamic-libs.log
-	# Configuring --disable-dynamic disables compliation of dynamic libraries.
+	# Configuring --disable-dynamic disables compilation of dynamic libraries.
 	GREP -v -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<

--- a/tests/Library.So/Test.mk
+++ b/tests/Library.So/Test.mk
@@ -11,9 +11,9 @@ $(eval $(ZMK.isolateHostToolchain))
 %.log: ZMK.makeOverrides += DEBUG=library.so
 # Some logs have DESTDIR set to /destdir
 %-destdir.log: ZMK.makeOverrides += DESTDIR=/destdir
-# Some logs behave as if configure --enable-static was used
+# Some logs behave as if configure --enable-dynamic was used
 %-enable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=yes
-# Some logs behave as if configure --disable -static was used
+# Some logs behave as if configure --disable-dynamic was used
 %-disable-dynamic-libs.log: ZMK.makeOverrides += Configure.DynamicLibraries=
 # Test depends on source files
 %.log: foo.c
@@ -95,8 +95,8 @@ clean-destdir: clean-destdir.log
 	GREP -qFx 'rm -f ./libbar.so-bar.d' <$<
 
 all-enable-dynamic-libs: all-enable-dynamic-libs.log
-    # Configuring --enable-dynamic enables compliation of dynamic libraries.
+	# Configuring --enable-dynamic enables compliation of dynamic libraries.
 	GREP -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<
 all-disable-dynamic-libs: all-disable-dynamic-libs.log
-    # Configuring --disable-dynamic disables compliation of dynamic libraries.
+	# Configuring --disable-dynamic disables compliation of dynamic libraries.
 	GREP -v -qFx 'cc -shared -Wl,-soname=libfoo.so.1 -o libfoo.so.1 libfoo.so.1-foo.o' <$<

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -26,6 +26,8 @@ Configure.TargetArchTriplet ?=
 Configure.DependencyTracking ?= yes
 Configure.MaintainerMode ?= yes
 Configure.SilentRules ?=
+Configure.StaticLibraries ?= yes
+Configure.DynamicLibraries ?= yes
 Configure.ProgramPrefix ?=
 Configure.ProgramSuffix ?=
 Configure.ProgramTransformName ?=
@@ -88,6 +90,10 @@ while [ "$$#" -ge 1 ]; do
             echo "                              Do not generate or use dependency data during builds"
             echo "  --enable-maintainer-mode    Enable maintainer mode (implicit)"
             echo "  --disable-maintainer-mode   Disable maintainer mode"
+            echo "  --enable-static             Enable static libraries"
+            echo "  --disable-static            Disable static libraries"
+            echo "  --enable-dynamic            Enable dynamic or shared libraries"
+            echo "  --disable-dynamic           Disable dynamic or shared libraries"
             echo
             echo "Build-time directory selection:"
             echo "  --prefix=PREFIX             Set prefix for all directories to PREFIX"
@@ -163,6 +169,11 @@ while [ "$$#" -ge 1 ]; do
 
         --enable-option-checking)       disableOptionChecking=no && shift ;;
         --disable-option-checking)      disableOptionChecking=yes && shift ;;
+
+        --enable-static)                staticLibraries=yes && shift ;;
+        --disable-static)               staticLibraries=no && shift ;;
+        --enable-dynamic)               dynamicLibraries=yes && shift ;;
+        --disable-dynamic)              dynamicLibraries=no && shift ;;
 
         --program-prefix=*)             programPrefix="$$(rhs "$$1")" && shift ;;
         --program-suffix=*)             programSuffix="$$(rhs "$$1")" && shift ;;
@@ -283,6 +294,33 @@ done
         implicit)
             echo "#   Configure.SilentRules was not specified."
             echo "#   This feature is disabled by default."
+            ;;
+    esac
+    echo "# Support for static libraries."
+    case "$${staticLibraries:-implicit}" in
+        yes)
+            echo "Configure.StaticLibraries=yes"
+            ;;
+        no)
+            echo "Configure.StaticLibraries="
+            ;;
+        implicit)
+            echo "#   Configure.StaticLibraries was not specified."
+            echo "#   This feature is enabled by default."
+            ;;
+    esac
+    echo
+    echo "# Support for dynamic or shared libraries."
+    case "$${dynamicLibraries:-implicit}" in
+        yes)
+            echo "Configure.DynamicLibraries=yes"
+            ;;
+        no)
+            echo "Configure.DynamicLibraries="
+            ;;
+        implicit)
+            echo "#   Configure.DynamicLibraries was not specified."
+            echo "#   This feature is enabled by default, if supported."
             ;;
     esac
     echo

--- a/zmk/Library.A.mk
+++ b/zmk/Library.A.mk
@@ -23,6 +23,7 @@ define Library.A.Template
 ifneq ($$(suffix $1),.a)
 $$(error library name $1 must end with ".a")
 endif
+ifeq ($(Configure.StaticLibraries),yes)
 
 # Compile library objects.
 $$(eval $$(call ZMK.Expand,ObjectGroup,$1))
@@ -38,4 +39,5 @@ $$(eval $$(call ZMK.Expand,InstallUninstall,$1))
 
 # React to "all" and "clean".
 $$(eval $$(call ZMK.Expand,AllClean,$1))
+endif # Configure.StaticLibraries
 endef

--- a/zmk/Library.DyLib.mk
+++ b/zmk/Library.DyLib.mk
@@ -20,6 +20,7 @@ $(eval $(call ZMK.Import,Toolchain))
 
 Library.DyLib.Variables=Sources ExportList
 define Library.DyLib.Template
+ifeq ($(Configure.DynamicLibraries),yes)
 
 # Compile library objects.
 $1: CFLAGS += -fpic
@@ -64,4 +65,5 @@ $$($1.alias).SymlinkTarget = $1
 $$(eval $$(call ZMK.Expand,Symlink,$$($1.alias)))
 endif
 
+endif # Configure.DynamicLibraries
 endef

--- a/zmk/Library.So.mk
+++ b/zmk/Library.So.mk
@@ -20,6 +20,7 @@ $(eval $(call ZMK.Import,Toolchain))
 
 Library.So.Variables=Sources SoName InstallDir VersionScript
 define Library.So.Template
+ifeq ($(Configure.DynamicLibraries),yes)
 
 # Compile library objects.
 $1: CFLAGS += -fpic
@@ -75,4 +76,5 @@ $$($1.alias).SymlinkTarget = $1
 $$(eval $$(call ZMK.Expand,Symlink,$$($1.alias)))
 endif
 
+endif # Configure.DynamicLibraries
 endef


### PR DESCRIPTION
Those configuration script options are now accepted and stored internally but
are not acted upon by the build system. Individually expanded Library.A,
Library.So and Library.DyLib templates become no-op when the corresponding
feature is disabled.

Fixes: https://github.com/zyga/zmk/issues/71
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>