### PR TITLE
Fix Symlink sub-directory install bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,16 @@ Changes in the next version:
 
 * The Symlink template is now documented with a dedicated manual page
 
+* The Symlink template no longer retains the sub-directory related to the
+  placement in the development tree after installation, matching the behavior
+  of the Program template.
+
+  This is a backwards incompatible change resulting from the fact that
+  previous behavior was simply wrong. There are additional tests checking
+  various combinations of this behavior now.
+
+  This issue is identified in ZMK.BugFixes as zmk-issue-80
+
 Changes in 0.5:
 
 * The Program.Test template no longer fails with syntax error when computing

--- a/man/zmk.Symlink.5.in
+++ b/man/zmk.Symlink.5.in
@@ -83,6 +83,29 @@ Path added to all installation targets.
 .Pp
 This variable is normally set externally, to install a compiled program
 into a staging area during construction of a compiled binary package.
+.Sh BUGS
+Prior to version 0.5.1, the
+.Em install
+target misbehaved when
+.Em $(link)
+contains a non-empty directory prefix. Incorrectly, the same prefix is
+replicated, somewhat confusingly in the installed symlink.
+.Pp
+Consider this example:
+.Bd -literal 4
+include z.mk
+subdir/link.SymlinkTarget = target
+subdir/link.InstallDir = $(bindir)
+$(eval $(call ZMK.Expand,Symlink,subdir/link))
+.Ed
+Running
+.Em make install
+on the following example would create the symbolic link
+.Em $(bindir)/subdir/link -> target,
+which was unexpected.
+.Pp
+This bug was given the identifier
+.Em zmk-issue-80 .
 .Sh HISTORY
 The
 .Nm

--- a/tests/Symlink/Makefile
+++ b/tests/Symlink/Makefile
@@ -1,9 +1,20 @@
 include z.mk
 
-name.InstallDir = /some/path
-name.SymlinkTarget=target
-$(eval $(call ZMK.Expand,Symlink,name))
+name1.InstallDir = /some/path
+name1.SymlinkTarget=target
+$(eval $(call ZMK.Expand,Symlink,name1))
 
-subdir/name.InstallDir = /other/path
-subdir/name.SymlinkTarget=../target
-$(eval $(call ZMK.Expand,Symlink,subdir/name))
+name2.InstallDir = /other/path
+name2.InstallName = custom-install-name2
+name2.SymlinkTarget=target
+$(eval $(call ZMK.Expand,Symlink,name2))
+
+subdir/name3.InstallDir = /other/path
+subdir/name3.SymlinkTarget=../target
+$(eval $(call ZMK.Expand,Symlink,subdir/name3))
+
+subdir/name4.InstallDir = /other/path
+subdir/name4.InstallName = custom-install-name4
+subdir/name4.SymlinkTarget=../target
+$(eval $(call ZMK.Expand,Symlink,subdir/name4))
+

--- a/tests/Symlink/Test.mk
+++ b/tests/Symlink/Test.mk
@@ -11,48 +11,64 @@ t:: all clean install uninstall \
 
 all: all.log
 	# Building a symlink just creates it.
-	GREP -qFx 'ln -sf target name' <$<
+	GREP -qFx 'ln -sf target name1' <$<
+	GREP -qFx 'ln -sf target name2' <$<
 	GREP -qFx 'install -d subdir' <$<
-	GREP -qFx 'ln -sf ../target subdir/name' <$<
+	GREP -qFx 'ln -sf ../target subdir/name3' <$<
+	GREP -qFx 'ln -sf ../target subdir/name4' <$<
 clean: clean.log
 	# Cleaning a symlink removes it.
-	GREP -qFx 'rm -f name' <$<
-	GREP -qFx 'rm -f subdir/name' <$<
+	GREP -qFx 'rm -f name1' <$<
+	GREP -qFx 'rm -f name2' <$<
+	GREP -qFx 'rm -f subdir/name3' <$<
+	GREP -qFx 'rm -f subdir/name4' <$<
 install: install.log
 	# Installing a symlink creates the install directory
 	# and then places the symlink there.
 	GREP -qFx 'install -d /some' <$<
 	GREP -qFx 'install -d /some/path' <$<
-	GREP -qFx 'ln -sf target /some/path/name' <$<
+	GREP -qFx 'ln -sf target /some/path/name1' <$<
+	GREP -qFx 'ln -sf target /other/path/custom-install-name2' <$<
 	GREP -qFx 'install -d /other' <$<
 	GREP -qFx 'install -d /other/path' <$<
-	GREP -qFx 'ln -sf ../target /other/path/subdir/name' <$<
+	GREP -qFx 'ln -sf ../target /other/path/name3' <$<
+	GREP -qFx 'ln -sf ../target /other/path/custom-install-name4' <$<
 uninstall: uninstall.log
 	# Uninstalling a symlink removes it.
-	GREP -qFx 'rm -f /some/path/name' <$<
-	GREP -qFx 'rm -f /other/path/subdir/name' <$<
+	GREP -qFx 'rm -f /some/path/name1' <$<
+	GREP -qFx 'rm -f /other/path/custom-install-name2' <$<
+	GREP -qFx 'rm -f /other/path/name3' <$<
+	GREP -qFx 'rm -f /other/path/custom-install-name4' <$<
 
 
 all-destdir: all-destdir.log
 	# Building a symlink just creates it.
-	GREP -qFx 'ln -sf target name' <$<
+	GREP -qFx 'ln -sf target name1' <$<
+	GREP -qFx 'ln -sf target name2' <$<
 	GREP -qFx 'install -d subdir' <$<
-	GREP -qFx 'ln -sf ../target subdir/name' <$<
+	GREP -qFx 'ln -sf ../target subdir/name3' <$<
+	GREP -qFx 'ln -sf ../target subdir/name4' <$<
 clean-destdir: clean-destdir.log
 	# Cleaning a symlink removes it.
-	GREP -qFx 'rm -f name' <$<
-	GREP -qFx 'rm -f subdir/name' <$<
+	GREP -qFx 'rm -f name1' <$<
+	GREP -qFx 'rm -f name2' <$<
+	GREP -qFx 'rm -f subdir/name3' <$<
+	GREP -qFx 'rm -f subdir/name4' <$<
 install-destdir: install-destdir.log
 	# Installing a symlink creates the install directory
 	# and then places the symlink there.
 	GREP -qFx 'mkdir -p /destdir' <$<
 	GREP -qFx 'install -d /destdir/some' <$<
 	GREP -qFx 'install -d /destdir/some/path' <$<
-	GREP -qFx 'ln -sf target /destdir/some/path/name' <$<
+	GREP -qFx 'ln -sf target /destdir/some/path/name1' <$<
+	GREP -qFx 'ln -sf target /destdir/other/path/custom-install-name2' <$<
 	GREP -qFx 'install -d /destdir/other' <$<
 	GREP -qFx 'install -d /destdir/other/path' <$<
-	GREP -qFx 'ln -sf ../target /destdir/other/path/subdir/name' <$<
+	GREP -qFx 'ln -sf ../target /destdir/other/path/name3' <$<
+	GREP -qFx 'ln -sf ../target /destdir/other/path/custom-install-name4' <$<
 uninstall-destdir: uninstall-destdir.log
 	# Uninstalling a symlink removes it.
-	GREP -qFx 'rm -f /destdir/some/path/name' <$<
-	GREP -qFx 'rm -f /destdir/other/path/subdir/name' <$<
+	GREP -qFx 'rm -f /destdir/some/path/name1' <$<
+	GREP -qFx 'rm -f /destdir/other/path/custom-install-name2' <$<
+	GREP -qFx 'rm -f /destdir/other/path/name3' <$<
+	GREP -qFx 'rm -f /destdir/other/path/custom-install-name4' <$<

--- a/z.mk
+++ b/z.mk
@@ -189,4 +189,5 @@ endef
 
 # List of identifiers of known bug fixes present in this build.
 define ZMK.BugFixes
+zmk-issue-80
 endef

--- a/zmk/Symlink.mk
+++ b/zmk/Symlink.mk
@@ -25,12 +25,11 @@ define Symlink.Template
 $1.InstallDir ?= $$(error define $1.InstallDir - the destination directory, or noinst to skip installation)
 $1.SymlinkTarget ?= $$(error define $1.SymlinkTarget - the target of the symbolic link)
 $1.InstallName ?= $$(notdir $1)
-$1.sourceDir = $$(patsubst %/,%,$$(dir $1))
 
 # Create the directory where the symbolic link is built in.
-$$(eval $$(call ZMK.Expand,Directory,$$($1.sourceDir)))
+$$(eval $$(call ZMK.Expand,Directory,$$(dir $1)))
 # Create the symbolic link in the build directory.
-$1: | $$($1.sourceDir)
+$1: | $$(patsubst %/,%,$$(dir $1))
 	$$(call Silent.Say,SYMLINK,$$@)
 	$$(Silent.Command)$$(strip ln -sf $$($1.SymlinkTarget) $$@)
 # React to "all" and "clean" targets.
@@ -40,18 +39,15 @@ $$(eval $$(call ZMK.Expand,AllClean,$1))
 ifneq ($$($1.InstallDir),noinst)
 
 # Create the directory where the symbolic link is installed to.
-$1.targetDir = $$(patsubst %/,%,$$(dir $$($1.InstallDir)/$1))
-$$(eval $$(call ZMK.Expand,Directory,$$($1.targetDir)))
+$$(eval $$(call ZMK.Expand,Directory,$$($1.InstallDir)))
 # Create the symbolic link in the install directory.
-$$(DESTDIR)$$($1.targetDir)/$$($1.InstallName):| $$(DESTDIR)$$($1.targetDir)
+$$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName):| $$(DESTDIR)$$($1.InstallDir)
 	$$(call Silent.Say,SYMLINK,$$@)
 	$$(Silent.Command)$$(strip ln -sf $$($1.SymlinkTarget) $$@)
 # React to "install" and "uninstall" targets.
-install:: $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName)
+install:: $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName)
 uninstall::
-	$$(call Silent.Say,RM,$$($1.targetDir)/$$($1.InstallName))
-	$$(Silent.Command)rm -f $$(DESTDIR)$$($1.targetDir)/$$($1.InstallName)
-else # noinst
-$1.targetDir = noinst
+	$$(call Silent.Say,RM,$$($1.InstallDir)/$$($1.InstallName))
+	$$(Silent.Command)rm -f $$(DESTDIR)$$($1.InstallDir)/$$($1.InstallName)
 endif # !noinst
 endef


### PR DESCRIPTION
I've noticed that the following rule has a surprising result:

    subdir/name.InstallDir = $(bindir)
    subdir/name.SymlinkTarget=target
    $(eval $(call ZMK.Expand,Symlink,subdir/name))

The symlink, as created by the install target is actually

    $(bindir)/subdir/name -> target

This is both unexpected for the users and problematic on the bigger
design vision, where the makefile could move from one directory to
another without impacting what the results are, as long as some prefix
directory is added or removed accordingly.

I've started looking at fixing this in a backwards compatible way, that
is, to allow developers to opt into the arguably correct behavior while
retaining the broken behavior by default. I came to the conclusion that
it is not the right thing to do because it's an unique property of the
Symlink template. The Program template does not behave this way.  In
fact, nothing else does, since everything except for the symlink uses
the InstallUninstall template under the hood.

In the end both the .sourceDir and .targetDir variables are removed. The
logic, when compared to InstallUninstall, is now very similar.

Fixes: https://github.com/zyga/zmk/issues/80
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>