### PR TITLE
Add ZMK.BugFixes property

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+Changes in the next version:
+
+* ZMK now defines `ZMK.BugFixes` as a set of identifiers of issues that were
+  known and addressed inside the library. Specific bugs may gain stable identifiers
+  that, once addressed, are added to the list in the next release of the library.
+
+  This mechanism is intended to enable hot-fixes, which are applied to the
+  makefile of a specific project, which update or replace part of zmk to fix a
+  specific issue while doing so in a way which eventually disables the
+  workaround.
+
 Changes in 0.5:
 
 * The Program.Test template no longer fails with syntax error when computing

--- a/man/z.mk.5.in
+++ b/man/z.mk.5.in
@@ -209,6 +209,10 @@ source directory. This may be a relative path.
 .Ss ZMK.ImportedModules
 The set of modules imported so far. This can be used for diagnostic purposes.
 Please import modules by calling
+.Ss ZMK.BugFixes
+A list of bug identifiers representing the set of bugs that are resolved in
+zmk. Membership test can be used to conditionally enable hot-fixes that patch
+a part of ZMK in a given project, when upgrading zmk itself is not feasible.
 .Nm ZMK.Import .
 .Ss VPATH
 When building out-of-tree, ZMK sets

--- a/z.mk
+++ b/z.mk
@@ -186,3 +186,7 @@ $$(eval $$(call $1.Template,$2))
 ZMK.expandStack := $$(shell expr $$(ZMK.expandStack) - 1)
 $$(if $$(findstring expand,$$(DEBUG)),$$(foreach n,$$($1.Variables),$$(eval $$(call ZMK.showVariable,$2.$$n))))
 endef
+
+# List of identifiers of known bug fixes present in this build.
+define ZMK.BugFixes
+endef


### PR DESCRIPTION
To quote the NEWS section:

ZMK now defines `ZMK.BugFixes` as a set of identifiers of issues that
were known and addressed inside the library. Specific bugs may gain
stable identifiers that, once addressed, are added to the list in the
next release of the library.

This mechanism is intended to enable hot-fixes, which are applied to the
makefile of a specific project, which update or replace part of zmk to
fix a specific issue while doing so in a way which eventually disables
the workaround.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>