### PR TITLE
Configure.mk: add support for --{enable,disable}-debug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+Changes in the next release:
+
+* The Configure module now sets `Configure.DebugBuild` to either `yes`, `no` or
+  empty value (default) in response to the `configure` script command line
+  options `--enable-debug` and `--disable-debug` respectively.
+
+* The Toolchain module adds `-g` to `CFLAGS` when `Configure.DebugBuild` is set
+  to `yes`.
+
 Changes in 0.5.1
 
 * ZMK now defines `ZMK.BugFixes` as a set of identifiers of issues that were

--- a/man/zmk.Configure.5.in
+++ b/man/zmk.Configure.5.in
@@ -182,6 +182,14 @@ When dynamic libraries are disabled the templates
 and
 .Nm Library.DyLib
 become inactive.
+.Ss Configure.DebugBuild
+This variable is controlled by the
+.Nm configure
+script options
+.Em --enable-debug
+and
+.Em --disable-debug .
+Debug builds are disabled by default.
 .Ss Configure.ProgramPrefix
 This variable is set by the
 .Nm configure

--- a/man/zmk.Toolchain.5.in
+++ b/man/zmk.Toolchain.5.in
@@ -46,6 +46,14 @@ or
 .Em -fpic .
 Please refer to your compiler manual for details.
 .Pp
+When
+.Nm Configure.Configured
+is non-empty and
+.Nm Configure.DebugBuild
+is non-empty then
+.Em -g
+is automatically appended and applies to all programs.
+.Pp
 This variable is often abused, mainly for simplicity, as a kitchen-sink that
 holds all of the compiler and linker options. This is discouraged.
 .Ss CPPFLAGS

--- a/tests/Configure/Test.mk
+++ b/tests/Configure/Test.mk
@@ -22,6 +22,8 @@ t:: \
 	config-disable-static \
 	config-enable-dynamic \
 	config-disable-dynamic \
+	config-enable-debug \
+	config-disable-debug \
 	config-program-prefix \
 	config-program-suffix \
 	config-program-transform-name \
@@ -87,6 +89,7 @@ debug-defaults: debug-defaults.log
 	GREP -qFx 'DEBUG: Configure.SilentRules=' <$<
 	GREP -qFx 'DEBUG: Configure.StaticLibraries=yes' <$<
 	GREP -qFx 'DEBUG: Configure.DynamicLibraries=yes' <$<
+	GREP -qFx 'DEBUG: Configure.DebugBuild=' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramPrefix=' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramSuffix=' <$<
 	GREP -qFx 'DEBUG: Configure.ProgramTransformName=' <$<
@@ -114,6 +117,7 @@ config-defaults: config.defaults.mk
 	GREP -v -qF 'Configure.SilentRules=' <$<
 	GREP -v -qF 'Configure.StaticLibraries=' <$<
 	GREP -v -qF 'Configure.DynamicLibraries=' <$<
+	GREP -v -qF 'Configure.DebugBuild=' <$<
 	GREP -v -qF 'Configure.ProgramPrefix=' <$<
 	GREP -v -qF 'Configure.ProgramSuffix=' <$<
 	GREP -v -qF 'Configure.ProgramTransformName=' <$<
@@ -191,6 +195,16 @@ config.disable-dynamic.mk: configureOptions += --disable-dynamic
 config-disable-dynamic: config.disable-dynamic.mk
 	# configure --disable-dynamic sets Configure.DynamicLibraries= (empty but set)
 	GREP -qFx 'Configure.DynamicLibraries=' <$<
+
+config.enable-debug.mk: configureOptions += --enable-debug
+config-enable-debug: config.enable-debug.mk
+	# configure --enable-debug sets Configure.DebugBuild=yes
+	GREP -qFx 'Configure.DebugBuild=yes' <$<
+
+config.disable-debug.mk: configureOptions += --disable-debug
+config-disable-debug: config.disable-debug.mk
+	# configure --disable-debug sets Configure.DebugBuild= (empty but set)
+	GREP -qFx 'Configure.DebugBuild=' <$<
 
 config.program-prefix.mk: configureOptions += --program-prefix=awesome-
 config-program-prefix: config.program-prefix.mk

--- a/tests/Toolchain/Test.mk
+++ b/tests/Toolchain/Test.mk
@@ -7,6 +7,7 @@ t:: debug-defaults debug-sysroot debug-dependency-tracking \
 	debug-watcom-win16-cc-detection debug-watcom-win16-cxx-detection \
 	debug-watcom-win32-cc-detection debug-watcom-win32-cxx-detection \
 	debug-gcc-configured-cross debug-g++-configured-cross \
+	debug-debug-build-enabled debug-debug-build-disabled
 
 # Test logs will contain debugging messages
 %.log: ZMK.makeOverrides += DEBUG=toolchain
@@ -186,3 +187,13 @@ debug-g++-configured-cross: debug-g++-configured-cross.log
 	GREP -qFx 'DEBUG: Toolchain.CXX.IsCross=yes' <$<
 	GREP -qFx 'DEBUG: Toolchain.ImageFormat=ELF' <$<
 	GREP -qFx 'DEBUG: Toolchain.IsCross=yes' <$<
+
+debug-debug-build-enabled.log: ZMK.makeOverrides += Configure.Configured=yes
+debug-debug-build-enabled.log: ZMK.makeOverrides += Configure.DebugBuild=yes
+debug-debug-build-enabled: debug-debug-build-enabled.log
+	GREP -qFx 'DEBUG: CFLAGS= -g' <$<
+
+debug-debug-build-disabled.log: ZMK.makeOverrides += Configure.Configured=yes
+debug-debug-build-disabled.log: ZMK.makeOverrides += Configure.DebugBuild=
+debug-debug-build-disabled: debug-debug-build-disabled.log
+	GREP -qFx 'DEBUG: CFLAGS= ' <$<

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -29,6 +29,7 @@ Configure.MaintainerMode ?= yes
 Configure.SilentRules ?=
 Configure.StaticLibraries ?= yes
 Configure.DynamicLibraries ?= yes
+Configure.DebugBuild ?=
 Configure.ProgramPrefix ?=
 Configure.ProgramSuffix ?=
 Configure.ProgramTransformName ?=
@@ -105,6 +106,8 @@ while [ "$$#" -ge 1 ]; do
             echo "  --disable-static            Disable static libraries"
             echo "  --enable-dynamic            Enable dynamic or shared libraries"
             echo "  --disable-dynamic           Disable dynamic or shared libraries"
+            echo "  --enable-debug              Enable debugging features"
+            echo "  --disable-debug             Disable debugging features"
             echo
             echo "Autotools compatibility options"
             echo "  --with-libtool-sysroot=DIR  Set the compiler sysroot to DIR"
@@ -191,6 +194,9 @@ while [ "$$#" -ge 1 ]; do
         --disable-static)               staticLibraries=no && shift ;;
         --enable-dynamic)               dynamicLibraries=yes && shift ;;
         --disable-dynamic)              dynamicLibraries=no && shift ;;
+
+        --enable-debug)                 debugBuild=yes && shift ;;
+        --disable-debug)                debugBuild=no && shift ;;
 
         --program-prefix=*)             programPrefix="$$(rhs "$$1")" && shift ;;
         --program-suffix=*)             programSuffix="$$(rhs "$$1")" && shift ;;
@@ -340,6 +346,19 @@ done
         implicit)
             echo "#   Configure.DynamicLibraries was not specified."
             echo "#   This feature is enabled by default, if supported."
+            ;;
+    esac
+    echo
+    echo "# Support for debugging."
+    case "$${debugBuild:-implicit}" in
+        yes)
+            echo "Configure.DebugBuild=yes"
+            ;;
+        no)
+            echo "Configure.DebugBuild="
+            ;;
+        implicit)
+            echo "#   Configure.DebugBuild was not specified."
             ;;
     esac
     echo

--- a/zmk/Toolchain.mk
+++ b/zmk/Toolchain.mk
@@ -33,6 +33,10 @@ TARGET_ARCH ?=
 LDLIBS ?=
 LDFLAGS ?=
 
+ifeq ($(Configure.Configured),yes)
+CFLAGS += $(if $(Configure.DebugBuild),-g)
+endif
+
 # The exe variable expands to .exe when the compiled binary should have such suffix.
 exe ?=
 


### PR DESCRIPTION
When enabled, Toolchain.mk causes CFLAGS to contain -g. No attempt is
made to filter out -g if the flag is disabled.

Closes: https://github.com/zyga/zmk/issues/90
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>