### PR TITLE
Add support for OBJC environment variable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Changes in the next release:
   empty value (default) in response to the `configure` script command line
   options `--enable-debug` and `--disable-debug` respectively.
 
+* The Toolchain and Configure modules support Objective-C better: the `OBJC`
+  environment variable is now recognized and remembered during configuration.
+  Documentation is updated to reflect this.
+
 * The Toolchain module adds `-g` to `CFLAGS` when `Configure.DebugBuild` is set
   to `yes`.
 

--- a/man/zmk.Toolchain.5.in
+++ b/man/zmk.Toolchain.5.in
@@ -36,6 +36,8 @@ The C compiler.
 The pre-processor, responsible for macros and include directives.
 .Ss CXX
 The C++ compiler.
+.Ss OBJC
+The Objective-C compiler.
 .Ss CFLAGS
 Configuration options for the C compiler.
 .Pp

--- a/tests/Configure/Test.mk
+++ b/tests/Configure/Test.mk
@@ -269,10 +269,9 @@ config.env-CXX.mk: configureEnvironment += CXX=potato-c++
 config-env-CXX: config.env-CXX.mk
 	GREP -qFx 'CXX=potato-c++' <$<
 
-# XFAIL: At present this is not implemented.
 config.env-OBJC.mk: configureEnvironment += OBJC=potato-objc
 config-env-OBJC: config.env-OBJC.mk
-	! GREP -qFx 'OBJC=potato-objc' <$<
+	GREP -qFx 'OBJC=potato-objc' <$<
 
 config.env-CFLAGS.mk: configureEnvironment += CFLAGS=-fpotato
 config-env-CFLAGS: config.env-CFLAGS.mk

--- a/zmk/Configure.mk
+++ b/zmk/Configure.mk
@@ -147,6 +147,7 @@ while [ "$$#" -ge 1 ]; do
             echo "Memorized environment variables:"
             echo "  CC                          Name of the C compiler"
             echo "  CXX                         Name of the C++ compiler"
+            echo "  OBJC                        Name of the Objective-C compiler"
             echo "  CFLAGS                      Options for the C compiler"
             echo "  CXXFLAGS                    Options for the C++ compiler"
             echo "  CPPFLAGS                    Options for the preprocessor"
@@ -222,6 +223,7 @@ while [ "$$#" -ge 1 ]; do
 
         CC=*)                           CC="$$(rhs "$$1")" && shift ;;
         CXX=*)                          CXX="$$(rhs "$$1")" && shift ;;
+        OBJC=*)                         OBJC="$$(rhs "$$1")" && shift ;;
         CFLAGS=*)                       CFLAGS="$$(rhs "$$1")" && shift ;;
         CXXFLAGS=*)                     CXXFLAGS="$$(rhs "$$1")" && shift ;;
         OBJCFLAGS=*)                    OBJCFLAGS="$$(rhs "$$1")" && shift ;;
@@ -273,6 +275,7 @@ done
     echo "# Inherited environment variables and overrides."
     test -n "$$CC"                  && echo "CC=$$CC"                           || echo "#   CC was not specified."
     test -n "$$CXX"                 && echo "CXX=$$CXX"                         || echo "#   CXX was not specified."
+    test -n "$$OBJC"                && echo "OBJC=$$OBJC"                       || echo "#   OBJC was not specified."
     test -n "$$CFLAGS"              && echo "CFLAGS=$$CFLAGS"                   || echo "#   CFLAGS was not specified."
     test -n "$$CXXFLAGS"            && echo "CXXFLAGS=$$CXXFLAGS"               || echo "#   CXXFLAGS was not specified."
     test -n "$$OBJCFLAGS"           && echo "OBJCFLAGS=$$OBJCFLAGS"             || echo "#   OBJCFLAGS was not specified."


### PR DESCRIPTION
The OBJC environment variable is supposed to be like CC but for Objective-C code. I caught this while looking at the definition of COMPILE.m in make source code, it refers to $OBJC, and then compiling with clang++ without gcc/gobjc support on the host.

Adjust XFAIL test to properly pass.