### PR TITLE
Do not look for self-tests in hidden directories

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -100,7 +100,8 @@ $(eval $(call ZMK.Expand,Tarball.Src,$(ZMK.releaseArchive)))
 check:: check-unit
 
 # Some hackery is performed to map slashes to dashes, except in "(lib)?hello-".
-tests = $(patsubst -%-,%,$(subst /,-,$(subst $(ZMK.SrcDir)/,/,$(dir $(shell find $(ZMK.SrcDir) -name Test.mk)))))
+# Exclude any files in hidden directories, such as .git.
+tests = $(patsubst -%-,%,$(subst /,-,$(subst $(ZMK.SrcDir)/,/,$(dir $(shell find $(ZMK.SrcDir) -not -path './.*' -name Test.mk)))))
 .PHONY: check-unit
 check-unit: $(addprefix check-,$(tests))
 .PHONY: $(addprefix check-,$(tests))

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Changes in the next release:
 * The Toolchain module adds `-g` to `CFLAGS` when `Configure.DebugBuild` is set
   to `yes`.
 
+* ZMK self-tests are no longer looking into hidden directories when looking for
+  unit tests. This notably fixes support for the Debian `dgit` tool which uses
+  `.git` for storing local state that looks like the source tree.
+
 Changes in 0.5.1
 
 * ZMK now defines `ZMK.BugFixes` as a set of identifiers of issues that were


### PR DESCRIPTION
There are various circumstances where hidden directory may contain what looks like a test we may want to run, but it would be futile to do so. Let's skip looking at any dot-files while looking for zmk tests.